### PR TITLE
Fixed Python version check to keep working for Python 4+

### DIFF
--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from collections import Mapping, Sequence
 from . import errors
 
-if sys.version_info[0] == 3:
+if sys.version_info[0] >= 3:
     _str_type = str
     _int_types = (int,)
 else:


### PR DESCRIPTION
This changes ensures the library keeps working in Python 4+.