### PR TITLE
Raise SchemaError for bad 'type'

### DIFF
--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -293,10 +293,13 @@ class Validator(object):
                 elif constraint in self.special_rules:
                     pass
                 elif constraint == 'schema':
-                    if constraints['type'] == 'list':
+                    constraint_type = constraints.get('type')
+                    if constraint_type == 'list':
                         self.validate_schema({'schema': value})
-                    else:
+                    elif constraint_type == 'dict':
                         self.validate_schema(value)
+                    else:
+                        raise SchemaError(errors.ERROR_SCHEMA_TYPE % field)
                 elif constraint == 'items':
                     if isinstance(value, Mapping):
                         # list of dicts, deprecated

--- a/cerberus/errors.py
+++ b/cerberus/errors.py
@@ -4,6 +4,7 @@ The test suite uses this module as well.
 """
 ERROR_SCHEMA_MISSING = "validation schema missing"
 ERROR_SCHEMA_FORMAT = "'%s' is not a schema, must be a dict"
+ERROR_SCHEMA_TYPE = "type of field '%s' must be either 'list' or 'dict'"
 ERROR_DOCUMENT_MISSING = "document is missing"
 ERROR_DOCUMENT_FORMAT = "'%s' is not a document, must be a dict"
 ERROR_UNKNOWN_RULE = "unknown rule '%s' for field '%s'"

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -32,10 +32,10 @@ class TestValidator(TestBase):
         self.assertSchemaError(self.document, schema, None,
                                errors.ERROR_SCHEMA_TYPE % field)
 
-        schema = {field: {'type': 'integer', 'schema': {'bar': {'type': 'string'}}}}
+        schema = {field: {'type': 'integer',
+                          'schema': {'bar': {'type': 'string'}}}}
         self.assertSchemaError(self.document, schema, None,
                                errors.ERROR_SCHEMA_TYPE % field)
-
 
     def _check_schema_content_error(self, err_msg, func, *args, **kwargs):
         try:

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -26,6 +26,17 @@ class TestValidator(TestBase):
         self.assertSchemaError(self.document, schema, v,
                                errors.ERROR_SCHEMA_FORMAT % schema)
 
+    def test_bad_schema_type_field(self):
+        field = 'foo'
+        schema = {field: {'schema': {'bar': {'type': 'string'}}}}
+        self.assertSchemaError(self.document, schema, None,
+                               errors.ERROR_SCHEMA_TYPE % field)
+
+        schema = {field: {'type': 'integer', 'schema': {'bar': {'type': 'string'}}}}
+        self.assertSchemaError(self.document, schema, None,
+                               errors.ERROR_SCHEMA_TYPE % field)
+
+
     def _check_schema_content_error(self, err_msg, func, *args, **kwargs):
         try:
             func(*args, **kwargs)


### PR DESCRIPTION
When `schema` is used, the type of the field has to be either `list` or `dict`:

    schema = {
        'foo': {'type': 'dict', 'schema': {'bar': {'type': 'string'}}
    }

This commit raises a `SchemaError` for missing or bad `'type'`-fields:
