### PR TITLE
Add 'allow_unknown' option for nested fields

### DIFF
--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -297,8 +297,6 @@ class Validator(object):
                     if not hasattr(self, '_validate_type_' + value):
                         raise SchemaError(
                             errors.ERROR_UNKNOWN_TYPE % value)
-                elif constraint in self.special_rules:
-                    pass
                 elif constraint == 'schema':
                     constraint_type = constraints.get('type')
                     if constraint_type == 'list':
@@ -307,6 +305,8 @@ class Validator(object):
                         self.validate_schema(value)
                     else:
                         raise SchemaError(errors.ERROR_SCHEMA_TYPE % field)
+                elif constraint in self.special_rules:
+                    pass
                 elif constraint == 'items':
                     if isinstance(value, Mapping):
                         # list of dicts, deprecated

--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -115,7 +115,8 @@ class Validator(object):
     .. versionadded:: 0.0.2
         Support for addition and validation of custom data types.
     """
-    special_rules = "required", "nullable", "type", "dependencies", "readonly"
+    special_rules = "required", "nullable", "type", "dependencies", "readonly",\
+                    "allow_unknown", "schema"
 
     def __init__(self, schema=None, transparent_schema_rules=False,
                  ignore_none_values=False, allow_unknown=False):
@@ -225,6 +226,12 @@ class Validator(object):
                     )
                     if self.errors.get(field):
                         continue
+
+                if 'schema' in definition:
+                    self._validate_schema(definition['schema'],
+                                          field,
+                                          value,
+                                          definition.get('allow_unknown'))
 
                 definition_rules = [rule for rule in definition.keys()
                                     if rule not in self.special_rules]
@@ -426,7 +433,7 @@ class Validator(object):
         if isinstance(value, _str_type) and len(value) == 0 and not empty:
             self._error(field, errors.ERROR_EMPTY_NOT_ALLOWED)
 
-    def _validate_schema(self, schema, field, value):
+    def _validate_schema(self, schema, field, value, nested_allow_unknown):
         if isinstance(value, Sequence):
             list_errors = {}
             for i in range(len(value)):
@@ -439,6 +446,8 @@ class Validator(object):
         elif isinstance(value, Mapping):
             validator = copy.copy(self)
             validator.schema = schema
+            if not validator.allow_unknown:
+                validator.allow_unknown = nested_allow_unknown
             validator.validate(value, context=self.document,
                                update=self.update)
             if len(validator.errors):

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -514,6 +514,26 @@ class TestValidator(TestBase):
         self.assertSuccess(document={"fred": "foo", "barney": "foo"},
                            validator=v)
 
+    def test_nested_unknown_keys(self):
+        schema = {
+            'field1': {
+                'type': 'dict',
+                'allow_unknown': True,
+                'schema': {'nested1': {'type': 'string'}}
+            }
+        }
+        document = {
+            'field1': {
+                'nested1': 'foo',
+                'arb1': 'bar',
+                'arb2': 42
+            }
+        }
+        self.assertSuccess(document=document, schema=schema)
+
+        schema['field1']['allow_unknown'] = {'type': 'string'}
+        self.assertFail(document=document, schema=schema)
+
     def test_novalidate_noerrors(self):
         '''In v0.1.0 and below `self.errors` raised an exception if no
         validation had been performed yet.


### PR DESCRIPTION
I would like to have nested fields with arbitrary keys:

```python
document = {
    'field1': {
        'nested1': 'foo'
        'arbitrary1': 'bar',
        'arbitrary2': 42
    }
}

schema = {
    'field1': {
        'type': 'dict',
        'allow_unknown': True,
        'schema': {
            'nested1': {'type': 'string'}
    }
}
```

`allow_unknown` can also be something like `{'type': 'string'}`.

