### PR TITLE
Adds Validator-initialization to example with `allow_unknown`

### DIFF
--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -49,7 +49,7 @@ class Validator(object):
                                  extend the schema grammar beyond Cerberus'
                                  domain.
     :param ignore_none_values: If ``True`` it will ignore None values for type
-                               checking. (no UnknowType error will be added).
+                               checking. (no UnknownType error will be added).
                                Defaults to ``False``. Useful if your document
                                is composed from function kwargs with defaults.
     :param allow_unknown: if ``True`` unknown key/value pairs (not present in
@@ -146,7 +146,7 @@ class Validator(object):
 
         :param schema: optional validation schema. Defaults to ``None``. If not
                        provided here, the schema must have been provided at
-                       class instantation.
+                       class instantiation.
         :return: True if validation succeeds, False otherwise. Check the
                  :func:`errors` property for a list of validation errors.
 
@@ -161,7 +161,7 @@ class Validator(object):
         :param document: the dict to validate.
         :param schema: the validation schema. Defaults to ``None``. If not
                        provided here, the schema must have been provided at
-                       class instantation.
+                       class instantiation.
         :param update: If ``True`` validation of required fields won't be
                        performed.
 
@@ -250,7 +250,7 @@ class Validator(object):
                         if not unknown_validator.validate({field: value}):
                             self._error(field, unknown_validator.errors[field])
                     else:
-                        # allow uknown field to pass without any kind of
+                        # allow unknown field to pass without any kind of
                         # validation
                         pass
                 else:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ Cerberus is an ISC Licensed validation tool for Python dictionaries.
 
 Cerberus provides type checking and other base functionality out of the box and
 is designed to be easily extensible, allowing for easy custom validation. It
-has no dependancies and is thoroughly tested under Python 2.6, Python 2.7,
+has no dependencies and is thoroughly tested under Python 2.6, Python 2.7,
 Python 3.3 and Python 3.4.
 
     *CERBERUS, n. The watch-dog of Hades, whose duty it was to guard the
@@ -13,7 +13,7 @@ Python 3.3 and Python 3.4.
     carry off the entrance. -Ambrose Bierce, The Devil's Dictionary*
 
 Usage
-------
+-----
 You define a validation schema and pass it to an instance of the
 :class:`~cerberus.Validator` class: ::
 
@@ -67,7 +67,7 @@ the first validation issue. The whole document will always be processed, and
     {'age': 'min value is 10', 'name': 'must be of string type'}
 
 You will still get :class:`~cerberus.SchemaError` and
-:class:`~cerberus.ValidationError` exceptions. 
+:class:`~cerberus.ValidationError` exceptions.
 
 Allowing the unknown
 ~~~~~~~~~~~~~~~~~~~~
@@ -82,6 +82,7 @@ By default only keys defined in the schema are allowed: ::
 However, you can allow unknown key/value pairs by either setting
 ``allow_unknown`` to ``True``: ::
 
+    >>> v = Validator(schema={})
     >>> v.allow_unknown = True
     >>> v.validate({'name': 'john', 'sex': 'M'})
     True
@@ -89,6 +90,7 @@ However, you can allow unknown key/value pairs by either setting
 Or you can set ``allow_unknown`` to a validation schema, in which case
 unknown fields will be validated against it: ::
 
+    >>> v = Validator(schema={})
     >>> v.allow_unknown = {'type': 'string'}
     >>> v.validate({'an_unknown_field': 'john'})
     True
@@ -107,7 +109,7 @@ unknown fields will be validated against it: ::
 
     >>> # by default allow_unknown is False for the whole document.
     >>> v = Validator()
-    >>> v.allow_unknown  
+    >>> v.allow_unknown
     False
 
     >>> # we can switch it on (or set it to a validation schema) for individual subdocuments
@@ -143,7 +145,7 @@ Custom validators
 Cerberus supports custom validation in two styles:
 
     * Class-based
-    * Function-based 
+    * Function-based
 
 As a general rule, when you are customizing validators in your application,
 ``Class-based`` style is more suitable for common validators, which are
@@ -250,10 +252,10 @@ the corresponding target values. ::
 
     >>> schema = {'name': {'type': 'string', 'maxlength': 10}}
 
-In the example above we define a target dictionary with only one key, ``name``, 
+In the example above we define a target dictionary with only one key, ``name``,
 which is expected to be a string not longer than 10 characters. Something like
 ``{'name': 'john doe'}`` would validate, while something like ``{'name': 'a
-very long string'}`` or ``{'name': 99}`` would not. 
+very long string'}`` or ``{'name': 99}`` would not.
 
 By definition all keys are optional unless the `required`_ rule is set for
 a key.
@@ -265,17 +267,17 @@ The following rules are currently supported:
 type
 ''''
 Data type allowed for the key value. Can be one of the following:
-    * ``string`` 
+    * ``string``
     * ``integer``
     * ``float``
     * ``number`` (integer or float)
     * ``boolean``
     * ``datetime``
     * ``dict`` (formally ``collections.mapping``)
-    * ``list`` (formally ``collections.sequence``, exluding strings)
+    * ``list`` (formally ``collections.sequence``, excluding strings)
     * ``set``
 
-You can extend this list and support custom types, see :ref:`new-types`. 
+You can extend this list and support custom types, see :ref:`new-types`.
 
 .. note::
 
@@ -367,9 +369,9 @@ but allowing for more fine grained control down to the field level. ::
 .. versionchanged:: 0.7 ``nullable`` is valid on fields lacking type definition.
 .. versionadded:: 0.3.0
 
-minlength, maxlength 
-'''''''''''''''''''' 
-Minimum and maximum length allowed for ``string`` and ``list`` types. 
+minlength, maxlength
+''''''''''''''''''''
+Minimum and maximum length allowed for ``string`` and ``list`` types.
 
 min, max
 ''''''''
@@ -573,7 +575,7 @@ but also any of their allowed values must be matched. ::
 
 
     >>> # same as using a dependencies list
-    >>> document = {'field2': 7}  
+    >>> document = {'field2': 7}
     >>> v.validate(document, schema)
     {'field2': "field 'field1' is required"}
 
@@ -601,7 +603,7 @@ Dependencies on sub-document fields are also supported: ::
     ...     }
     ...   }
     ... }
-            
+
     >>> document = {'test_field': 'foobar', 'a_dict': {'foo': 'foo'}}
     >>> v.validate(document, schema)
     False
@@ -647,7 +649,7 @@ to do is: ::
 
 Testing
 -------
-.. image:: https://secure.travis-ci.org/nicolaiarocci/cerberus.png?branch=master 
+.. image:: https://secure.travis-ci.org/nicolaiarocci/cerberus.png?branch=master
         :target: https://secure.travis-ci.org/nicolaiarocci/cerberus
 
 ::
@@ -664,7 +666,7 @@ Copyright Notice
 This is an open source project by `Nicola Iarocci
 <http://nicolaiarocci.com>`_. See the original `LICENSE
 <https://github.com/nicolaiarocci/cerberus/blob/master/LICENSE>`_ for more
-informations.
+information.
 
 .. _`Regular Expressions Syntax`: https://docs.python.org/2/library/re.html#regular-expression-syntax
 .. _`Validating user objects with Cerberus`: http://nicolaiarocci.com/validating-user-objects-cerberus/


### PR DESCRIPTION
 This is supposed to clarify that an empty dict has to be provided.
 Also fixes some spellings.