### PR TITLE
Allows to validate against a set of types.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,13 +15,14 @@ Patches and Suggestions
 - Denis Carriere
 - Eelke Hermens
 - Florian Rathgeber
+- Frank Sachsenheim
 - Harro van der Klauw
 - Jaroslav Semančík
 - Kaleb Pomeroy
 - Kirill Pavlov
 - Lujeni
 - Luo Peng
-- Martijn Vermaat 
+- Martijn Vermaat
 - Martin Ortbauer
 - Nikita Vlaznev
 - Paul Weaver

--- a/cerberus/tests/__init__.py
+++ b/cerberus/tests/__init__.py
@@ -45,6 +45,10 @@ class TestBase(unittest.TestCase):
             'a_set': {
                 'type': 'set',
             },
+            'one_or_more_strings': {
+                'type': ['string', 'list'],
+                'schema': {'type': 'string'}
+            },
             'a_regex_email': {
                 'type': 'string',
                 'regex': '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$'

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -315,6 +315,12 @@ class TestValidator(TestBase):
     def test_set(self):
         self.assertSuccess({'a_set': set(['hello', 1])})
 
+    def test_one_of_two_types(self):
+        self.assertSuccess({'one_or_more_strings': 'foo'})
+        self.assertSuccess({'one_or_more_strings': ['foo', 'bar']})
+        self.assertFail({'one_or_more_strings': 23})
+        self.assertFail({'one_or_more_strings': ['foo', 23]})
+
     def test_regex(self):
         field = 'a_regex_email'
         self.assertSuccess({field: 'valid.email@gmail.com'})
@@ -535,15 +541,17 @@ class TestValidator(TestBase):
         self.assertFail(document=document, schema=schema)
 
     def test_novalidate_noerrors(self):
-        '''In v0.1.0 and below `self.errors` raised an exception if no
+        """
+        In v0.1.0 and below `self.errors` raised an exception if no
         validation had been performed yet.
-        '''
+        """
         self.assertEqual(self.validator.errors, {})
 
     def test_callable_validator(self):
-        ''' Validator instance is callable, functions as a shorthand
+        """
+        Validator instance is callable, functions as a shorthand
         passthrough to validate()
-        '''
+        """
         schema = {'test_field': {'type': 'string'}}
         v = Validator(schema)
         self.assertTrue(v.validate({'test_field': 'foo'}))
@@ -707,11 +715,11 @@ class TestValidator(TestBase):
                                                  'unknown': True}}))
 
     def test_self_document_always_root(self):
-        ''' Make sure self.document is always the root document.
+        """ Make sure self.document is always the root document.
         See:
         * https://github.com/nicolaiarocci/cerberus/pull/42
         * https://github.com/nicolaiarocci/eve/issues/295
-        '''
+        """
         class MyValidator(Validator):
             def _validate_root_doc(self, root_doc, field, value):
                 if('sub' not in self.document or

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -275,7 +275,15 @@ Data type allowed for the key value. Can be one of the following:
     * ``list`` (formally ``collections.sequence``, exluding strings)
     * ``set``
 
-You can extend this list and support custom types, see :ref:`new-types`. 
+A list of types can be used to allow different values: ::
+
+    >>> v = Validator({'quotes': {'type': ['string', 'list'], 'schema': {'type': 'string'}})
+    >>> v.validate({'quotes': 'Hello world!'})
+    True
+    >>> v.validate({'quotes': ['Do not disturb my circles!', 'Heureka!']})
+    True
+
+You can extend this list and support custom types, see :ref:`new-types`.
 
 .. note::
 
@@ -285,6 +293,9 @@ You can extend this list and support custom types, see :ref:`new-types`.
     validation rules on the field will be skipped and validation will continue
     on other fields. This allows to safely assume that field type is correct
     when other (standard or custom) rules are invoked.
+
+.. versionchanged:: 0.8.2
+   If a list of types is given, the key value must match *any* of them.
 
 .. versionchanged:: 0.7.1
    ``dict`` and ``list`` typechecking are now performed with the more generic


### PR DESCRIPTION
See added documentation and test for usage. If this doesn't clarify, these should be extended.

- fixes also some minor formatting issues of docstrings
- omit regex-checks on non-string-types