### PR TITLE
Follow-up of checking against multiple types

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,13 +15,14 @@ Patches and Suggestions
 - Denis Carriere
 - Eelke Hermens
 - Florian Rathgeber
+- Frank Sachsenheim
 - Harro van der Klauw
 - Jaroslav Semančík
 - Kaleb Pomeroy
 - Kirill Pavlov
 - Lujeni
 - Luo Peng
-- Martijn Vermaat 
+- Martijn Vermaat
 - Martin Ortbauer
 - Nikita Vlaznev
 - Paul Weaver

--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -363,17 +363,23 @@ class Validator(object):
             self._error(field, errors.ERROR_REGEX % match)
 
     def _validate_type(self, data_type, field, value):
-        data_types = data_type if isinstance(data_type, list) else [data_type]
-        for data_type in data_types:
-            validator = getattr(self, "_validate_type_" + data_type, None)
+
+        def call_type_validation(_type, value):
+            validator = getattr(self, "_validate_type_" + _type, None)
             validator(field, value)
-        if field in self._errors.keys():
-            if isinstance(self._errors[field], str):
-                _errors = 1
-            elif isinstance(self._errors[field], list):
-                _errors = len(self._errors[field])
-            if _errors < len(data_types):
-                del self._errors[field]
+
+        if isinstance(data_type, _str_type):
+            call_type_validation(data_type, value)
+        elif isinstance(data_type, list):
+            prev_errors = self._errors.copy()
+            for _type in data_type:
+                call_type_validation(_type, value)
+                if len(self._errors) == len(prev_errors):
+                    return
+                else:
+                    self._errors = prev_errors
+            self._error(field, errors.ERROR_BAD_TYPE % ", ".
+                        join(data_type[:-1]) + ' or ' + data_type[-1])
 
     def _validate_type_string(self, field, value):
         if not isinstance(value, _str_type):
@@ -453,7 +459,7 @@ class Validator(object):
             self._error(field, errors.ERROR_EMPTY_NOT_ALLOWED)
 
     def _validate_schema(self, schema, field, value, nested_allow_unknown):
-        if isinstance(value, Sequence):
+        if isinstance(value, Sequence) and not isinstance(value, _str_type):
             list_errors = {}
             for i in range(len(value)):
                 validator = self.__class__({i: schema},
@@ -471,10 +477,10 @@ class Validator(object):
                                update=self.update)
             if len(validator.errors):
                 self._error(field, validator.errors)
-        else:
-            self._error(field, errors.ERROR_BAD_TYPE % "dict or list")
 
     def _validate_keyschema(self, schema, field, value):
+        if not isinstance(value, Mapping):
+            return
         for key, document in value.items():
             validator = self.__class__()
             validator.validate(

--- a/cerberus/tests/__init__.py
+++ b/cerberus/tests/__init__.py
@@ -45,6 +45,10 @@ class TestBase(unittest.TestCase):
             'a_set': {
                 'type': 'set',
             },
+            'one_or_more_strings': {
+                'type': ['string', 'list'],
+                'schema': {'type': 'string'}
+            },
             'a_regex_email': {
                 'type': 'string',
                 'regex': '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$'

--- a/cerberus/tests/__init__.py
+++ b/cerberus/tests/__init__.py
@@ -131,7 +131,7 @@ class TestBase(unittest.TestCase):
             validator.validate(document, schema)
         except known_exception as e:
             self.assertTrue(msg == str(e)) if msg else self.assertTrue(True)
-        except Exception as e:
+        except Exception as e:  # noqa
             self.fail("%s not raised." % known_exception)
 
     def assertFail(self, document, schema=None, validator=None):

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -4,6 +4,7 @@ from random import choice
 from string import ascii_lowercase
 from . import TestBase
 from ..cerberus import Validator, errors, SchemaError
+from unittest import skip
 
 
 class TestValidator(TestBase):
@@ -313,7 +314,7 @@ class TestValidator(TestBase):
         self.assertSuccess({'an_array': ['agent', 'client']})
 
     def test_set(self):
-        self.assertSuccess({'a_set': set(['hello', 1])})
+        self.assertSuccess({'a_set': {'hello', 1}})
 
     def test_one_of_two_types(self):
         self.assertSuccess({'one_or_more_strings': 'foo'})
@@ -761,3 +762,19 @@ class TestValidator(TestBase):
         self.assertError('name', 'must be lowercase', validator=v)
 
         self.assertSuccess({'name': 'itsme', 'age': 2}, validator=v)
+
+
+class TestDockerCompose(TestBase):
+    """ Tests for https://github.com/docker/compose """
+    def setUp(self):
+        self.validator = Validator()
+
+    @skip('is not supported yet.')
+    def test_environment(self):
+        schema = {'environment': {'type': ['dict', 'list'], 'keyschema': {'type': 'string', 'nullable': True}, 'schema': {'type': 'string'}}}
+
+        document = {'environment': {'VARIABLE': 'FOO'}}
+        self.assertSuccess(document, schema)
+
+        document = {'environment': ['VARIABLE=FOO']}
+        self.assertSuccess(document, schema)

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -315,6 +315,12 @@ class TestValidator(TestBase):
     def test_set(self):
         self.assertSuccess({'a_set': set(['hello', 1])})
 
+    def test_one_of_two_types(self):
+        self.assertSuccess({'one_or_more_strings': 'foo'})
+        self.assertSuccess({'one_or_more_strings': ['foo', 'bar']})
+        self.assertFail({'one_or_more_strings': 23})
+        self.assertFail({'one_or_more_strings': ['foo', 23]})
+
     def test_regex(self):
         field = 'a_regex_email'
         self.assertSuccess({field: 'valid.email@gmail.com'})
@@ -535,15 +541,17 @@ class TestValidator(TestBase):
         self.assertFail(document=document, schema=schema)
 
     def test_novalidate_noerrors(self):
-        '''In v0.1.0 and below `self.errors` raised an exception if no
+        """
+        In v0.1.0 and below `self.errors` raised an exception if no
         validation had been performed yet.
-        '''
+        """
         self.assertEqual(self.validator.errors, {})
 
     def test_callable_validator(self):
-        ''' Validator instance is callable, functions as a shorthand
+        """
+        Validator instance is callable, functions as a shorthand
         passthrough to validate()
-        '''
+        """
         schema = {'test_field': {'type': 'string'}}
         v = Validator(schema)
         self.assertTrue(v.validate({'test_field': 'foo'}))
@@ -707,11 +715,11 @@ class TestValidator(TestBase):
                                                  'unknown': True}}))
 
     def test_self_document_always_root(self):
-        ''' Make sure self.document is always the root document.
+        """ Make sure self.document is always the root document.
         See:
         * https://github.com/nicolaiarocci/cerberus/pull/42
         * https://github.com/nicolaiarocci/eve/issues/295
-        '''
+        """
         class MyValidator(Validator):
             def _validate_root_doc(self, root_doc, field, value):
                 if('sub' not in self.document or

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -275,7 +275,15 @@ Data type allowed for the key value. Can be one of the following:
     * ``list`` (formally ``collections.sequence``, exluding strings)
     * ``set``
 
-You can extend this list and support custom types, see :ref:`new-types`. 
+A list of types can be used to allow different values: ::
+
+    >>> v = Validator({'quotes': {'type': ['string', 'list'], 'schema': {'type': 'string'}})
+    >>> v.validate({'quotes': 'Hello world!'})
+    True
+    >>> v.validate({'quotes': ['Do not disturb my circles!', 'Heureka!']})
+    True
+
+You can extend this list and support custom types, see :ref:`new-types`.
 
 .. note::
 
@@ -285,6 +293,9 @@ You can extend this list and support custom types, see :ref:`new-types`.
     validation rules on the field will be skipped and validation will continue
     on other fields. This allows to safely assume that field type is correct
     when other (standard or custom) rules are invoked.
+
+.. versionchanged:: 0.8.2
+   If a list of types is given, the key value must match *any* of them.
 
 .. versionchanged:: 0.7.1
    ``dict`` and ``list`` typechecking are now performed with the more generic


### PR DESCRIPTION
- improves failure message when testing against multiple types
- ignores `keyschema` when not a mapping
- ignores `schema` when not a sequence
- adds a failing test concerning validating dict and list as allowed value
  in conjunction with keyschema and schema
- some minor code fixes

sadly there's still an issue that is documented as a test. shall i add this documentation?
since i actually don't need this, i will not fix it. unless the universe stops expanding, maybe i find the time then.

also, i seem to miss a point about rebasing. so you should just cherry-pick 875e8f6