### PR TITLE
Follow-up of checking against multiple types

### DIFF
--- a/cerberus/tests/__init__.py
+++ b/cerberus/tests/__init__.py
@@ -131,7 +131,7 @@ class TestBase(unittest.TestCase):
             validator.validate(document, schema)
         except known_exception as e:
             self.assertTrue(msg == str(e)) if msg else self.assertTrue(True)
-        except Exception as e:
+        except Exception as e:  # noqa
             self.fail("%s not raised." % known_exception)
 
     def assertFail(self, document, schema=None, validator=None):

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -761,3 +761,20 @@ class TestValidator(TestBase):
         self.assertError('name', 'must be lowercase', validator=v)
 
         self.assertSuccess({'name': 'itsme', 'age': 2}, validator=v)
+
+
+class TestDockerCompose(TestBase):
+    """ Tests for https://github.com/docker/compose """
+    def setUp(self):
+        self.validator = Validator()
+
+    def test_environment(self):
+        schema = {'environment': {'type': ['dict', 'list'],
+                  'keyschema': {'type': 'string', 'nullable': True},
+                  'schema': {'type': 'string'}}}
+
+        document = {'environment': {'VARIABLE': 'FOO'}}
+        self.assertSuccess(document, schema)
+
+        document = {'environment': ['VARIABLE=FOO']}
+        self.assertSuccess(document, schema)


### PR DESCRIPTION
- improves failure message when testing against multiple types
- ignores `keyschema` when not a mapping
- ignores `schema` when not a sequence
- adds a failing test concerning validating dict and list as allowed value
  in conjunction with keyschema and schema
- some minor code fixes

sadly there's still an issue that is documented as a test. shall i add this documentation?
since i actually don't need this, i will not fix it. unless the universe stops expanding, maybe i find the time then.