### PR TITLE
Allows specification of a prefix for error sources

### DIFF
--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -122,11 +122,13 @@ class Validator(object):
                     "allow_unknown", "schema", "coerce"
 
     def __init__(self, schema=None, transparent_schema_rules=False,
-                 ignore_none_values=False, allow_unknown=False, **kwargs):
+                 ignore_none_values=False, allow_unknown=False,
+                 error_source_prefix='', **kwargs):
         self.schema = schema
         self.transparent_schema_rules = transparent_schema_rules
         self.ignore_none_values = ignore_none_values
         self.allow_unknown = allow_unknown
+        self.error_source_prefix = error_source_prefix
         self._additional_kwargs = kwargs
 
         if schema:
@@ -273,6 +275,11 @@ class Validator(object):
         return len(self._errors) == 0
 
     def _error(self, field, _error):
+        if isinstance(field, int):
+            field = '[' + str(field) + ']'
+        if self.error_source_prefix is not None:
+            field = self.error_source_prefix + field
+
         field_errors = self._errors.get(field, [])
 
         if not isinstance(field_errors, list):

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -223,9 +223,9 @@ class TestValidator(TestBase):
         value = ['a string', 'not an integer']
         self.assertFail({field: value})
         v = self.validator
-        self.assertTrue(1 in v.errors)
+        self.assertTrue('[1]' in v.errors)
         self.assertTrue(errors.ERROR_BAD_TYPE % 'integer' in
-                        v.errors[1])
+                        v.errors['[1]'])
 
         value = ['a string', 10, 'an extra item']
         self.assertFail({field: value})
@@ -252,10 +252,10 @@ class TestValidator(TestBase):
         self.assertFail({field: value})
         v = self.validator
         self.assertTrue(field in v.errors)
-        self.assertTrue(0 in v.errors[field])
-        self.assertTrue('price' in v.errors[field][0])
+        self.assertTrue('[0]' in v.errors[field])
+        self.assertTrue('price' in v.errors[field]['[0]'])
         self.assertTrue(errors.ERROR_BAD_TYPE % 'integer' in
-                        v.errors[field][0]['price'])
+                        v.errors[field]['[0]']['price'])
 
         value = ["not a dict"]
         self.assertValidationError({field: value}, None, None,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,19 @@ the first validation issue. The whole document will always be processed, and
 You will still get :class:`~cerberus.SchemaError` and
 :class:`~cerberus.ValidationError` exceptions.
 
+If you want to aggregate the errors of several, equally structured documents,
+you may set a prefix that will be prepended to the keys of the dictionary that
+contains all encountered errors. ::
+
+    >>> v = Validator(schema, error_source_prefix='myprefix')
+
+    v = Validator(schema)
+    errors = {}
+    for name, doc in documents.items():
+        v.error_source_prefix = name + ':'
+        v.validate(doc)
+        errors.update(v.errors)
+
 Allowing the unknown
 ~~~~~~~~~~~~~~~~~~~~
 By default only keys defined in the schema are allowed: ::


### PR DESCRIPTION
This makes the output more meaningful in case one checks several documents and
aggregates their errors.
Also changes the type and format of list-item-index to match Python's index-
syntax.