### PR TITLE
Adds 'propertyschema'-validation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -30,6 +30,7 @@ Not released yet
   Betz).
 - Fix: raise SchemaError when an unallowed 'type' is used in conjunction with
   'schema' rule (Tobias Betz).
+- Added 'propertyschema' validation rule (Frank Sachsenheim).
 
 Version 0.8.1
 -------------

--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -64,6 +64,7 @@ class Validator(object):
        'type' can be a list of valid types.
        'keyschema' is renamed to 'valueschema'. Closes #92.
        'coerce' rule
+       'propertyschema' validation rule.
        additional kwargs that are passed to the __init__-method of an
        instance of Validator-(sub-)class are passed to child-validators.
        :func:`validated` added
@@ -549,6 +550,15 @@ class Validator(object):
                     {key: document}, {key: schema}, context=self.document)
                 if len(validator.errors):
                     self._error(field, validator.errors)
+
+    def _validate_propertyschema(self, schema, field, value):
+        if isinstance(value, Mapping):
+            validator = self.__get_child_validator(
+                schema={field: {'type': 'list', 'schema': schema}})
+            validator.validate({field: list(value.keys())},
+                               context=self.document)
+            for error in validator.errors:
+                self._error(field, error)
 
     def _validate_items(self, items, field, value):
         if isinstance(items, Mapping):

--- a/cerberus/tests/__init__.py
+++ b/cerberus/tests/__init__.py
@@ -104,6 +104,10 @@ class TestBase(unittest.TestCase):
                 'type': 'dict',
                 'valueschema': {'type': 'integer'}
             },
+            'a_dict_with_propertyschema': {
+                'type': 'dict',
+                'propertyschema': {'type': 'string', 'regex': '[a-z]+'}
+            },
             'a_list_length': {
                 'type': 'list',
                 'schema': {'type': 'integer'},

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -599,6 +599,23 @@ keys, the values for all of which must validate with given schema: ::
 .. versionchanged:: 0.9
    renamed ``keyschema`` to ``valueschema``
 
+propertyschema
+''''''''''''''
+
+This is the counterpart to ``valueschema`` that validates the `keys` of a ``dict``. For historical reasons
+it is `not` named ``keyschema``. ::
+
+    >>> schema = 'a_dict': {'type': 'dict', 'propertyschema': {'type': 'string', 'regex': '[a-z]+'}}
+    >>> document = {'a_dict': {'key': 'value'}}
+    >>> v.validate(document, schema)
+    True
+
+    >>> document = {'a_dict': {'KEY': 'value'}}
+    >>> v.validate(document, schema)
+    False
+
+.. versionadded:: 0.9
+
 regex
 '''''
 Validation will fail if field value does not match the provided regex rule. Only applies to string fiels. ::


### PR DESCRIPTION
this isn't finished at all yet.

but i'm irritated that the failure-test in `test_a_dict_with_propertyschema` passes, as there is currently nothing implemented that detects an error.

@nicolaiarocci any idea what my mistake is here?