### PR TITLE
Fixes non-failing tests

### DIFF
--- a/cerberus/__init__.py
+++ b/cerberus/__init__.py
@@ -8,10 +8,9 @@
 
 """
 
-__version__ = "0.8.2-dev"
-
 from .cerberus import Validator, ValidationError, SchemaError
 
+__version__ = "0.8.2-dev"
 
 __all__ = [
     Validator.__name__,

--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -19,8 +19,8 @@ if sys.version_info[0] == 3:
     _str_type = str
     _int_types = (int,)
 else:
-    _str_type = basestring
-    _int_types = (int, long)
+    _str_type = basestring  # noqa
+    _int_types = (int, long)  # noqa
 
 
 class ValidationError(ValueError):
@@ -121,8 +121,8 @@ class Validator(object):
     .. versionadded:: 0.0.2
         Support for addition and validation of custom data types.
     """
-    special_rules = "required", "nullable", "type", "dependencies", "readonly",\
-                    "allow_unknown", "schema", "coerce"
+    special_rules = "required", "nullable", "type", "dependencies", \
+                    "readonly", "allow_unknown", "schema", "coerce"
 
     def __init__(self, schema=None, transparent_schema_rules=False,
                  ignore_none_values=False, allow_unknown=False, **kwargs):
@@ -367,8 +367,8 @@ class Validator(object):
         required = list(field for field, definition in self.schema.items()
                         if definition.get('required') is True)
         missing = set(required) - set(key for key in document.keys()
-                                      if document.get(key) is not None
-                                      or not self.ignore_none_values)
+                                      if document.get(key) is not None or
+                                      not self.ignore_none_values)
 
         for field in missing:
             dependencies = self.schema[field].get('dependencies')

--- a/cerberus/tests/__init__.py
+++ b/cerberus/tests/__init__.py
@@ -4,15 +4,18 @@ from ..cerberus import Validator, SchemaError, ValidationError, errors
 
 class TestBase(unittest.TestCase):
 
+    required_string_extension = {
+        'a_required_string': {'type': 'string',
+                              'minlength': 2,
+                              'maxlength': 10,
+                              'required': True}}
+
     def setUp(self):
         self.document = {'name': 'john doe'}
         self.schema = {
-            'a_required_string': {
-                'type': 'string',
-                'minlength': 2,
-                'maxlength': 10,
-                'required': True,
-            },
+            'a_string': {'type': 'string',
+                         'minlength': 2,
+                         'maxlength': 10},
             'a_nullable_integer': {
                 'type': 'integer',
                 'nullable': True


### PR DESCRIPTION
i came to the conclusion why [a test didn't fail](https://github.com/nicolaiarocci/cerberus/pull/98#issue-80170445).

as any test that doesn't match a requirement fails, the required field is removed from TestBase.schema.
also a test checks the expected behaviour of TestBase.

includes code formattings that are enforced by tighter flake8-rules.