### PR TITLE
Adds wrapper-method `validated`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,8 @@ Not released yet
   Betz).
 - Fix: raise SchemaError when an unallowed 'type' is used in conjunction with
   'schema' rule (Tobias Betz).
+- 'validator.validated' takes a document as argument and returns a validated
+  document or 'None' if validation failed (Frank Sachsenheim).
 
 Version 0.8.1
 -------------

--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -66,6 +66,7 @@ class Validator(object):
        'coerce' rule
        additional kwargs that are passed to the __init__-method of an
        instance of Validator-(sub-)class are passed to child-validators.
+       :func:`validated` added
 
     .. versionchanged:: 0.8.1
        'dependencies' for sub-document fields. Closes #64.
@@ -184,6 +185,16 @@ class Validator(object):
            Support for update mode.
         """
         return self._validate(document, schema, update=update, context=context)
+
+    def validated(self, *args, **kwargs):
+        """ Wrapper around ``Validator.validate`` that returns the validated
+        document or ``None`` if validation failed.
+        """
+        self.validate(*args, **kwargs)
+        if self.errors:
+            return None
+        else:
+            return self.document
 
     def _validate(self, document, schema=None, update=False, context=None):
 

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from datetime import datetime
 from random import choice
 from string import ascii_lowercase
@@ -812,6 +813,17 @@ class TestValidator(TestBase):
         v = Validator(schema)
         self.assertFalse(v.validate({'name': 1234}))
         self.assertError('name', errors.ERROR_COERCION_FAILED % 'name', v)
+
+    def test_validated(self):
+        schema = {'property': {'type': 'string'}}
+        v = Validator(schema)
+        document = {'property': 'string'}
+        self.assertEqual(v.validated(document), document)
+        document = {'property': 0}
+        if sys.version_info[0] * 10 + sys.version_info[1] < 27:
+            self.assertEqual(v.validated(document), None)
+        else:
+            self.assertIsNone(v.validated(document))
 
 
 # TODO remove on next major release

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -285,6 +285,12 @@ validated. ::
     >>> v.document
     {'flag': True}
 
+There's a wrapper-method ``validated`` that returns the validated document for
+flows like this: ::
+
+    v = Validator(schema)
+    valid_documents = [x for x in [v.validated(y) for y in documents] if x is not None]
+
 If a coercion callable raises a ``TypeError`` or ``ValueError`` then the
 exception will be caught and the validation with fail.  All other exception pass
 through.


### PR DESCRIPTION
takes a document as argument and returns a validated document or 'None' if validation failed as a helper for cases where the processed document is used

documentation updated

may partly solve #95