### PR TITLE
Issue 107

### DIFF
--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -853,7 +853,14 @@ class TestValidator(TestBase):
     def test_issue_107(self):
         schema = {'info': {'type': 'dict',
                   'schema': {'name': {'type': 'string', 'required': True}}}}
-        self.assertSuccess({'info': {'name': 'my name'}}, schema)
+        document = {'info': {'name': 'my name'}}
+        self.assertSuccess(document, schema)  # does not fail
+
+        validator = Validator(schema)
+        self.assertSuccess(document, schema, validator)  # does not fail
+
+        if not validator.validate(document):
+            raise AssertionError("Document did not validate")  # fails
 
 
 # TODO remove on next major release

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -850,6 +850,11 @@ class TestValidator(TestBase):
         else:
             self.assertIsNone(v.validated(document))
 
+    def test_issue_107(self):
+        schema = {'info': {'type': 'dict',
+                  'schema': {'name': {'type': 'string', 'required': True}}}}
+        self.assertSuccess({'info': {'name': 'my name'}}, schema)
+
 
 # TODO remove on next major release
 class BackwardCompatibility(TestBase):


### PR DESCRIPTION
this this still WIP, the PR is intended to run travis' tests and discuss changes.
eventually it shall solve #107.

state of progress:

i haven't yet figured out why the tests do not fail when `assertSuccess` is used. but i think this is an important issue.

i can confirm that referring `self.document` in cerberus.py#302 makes a difference.

the failure was then caused by the fact, that in `_validate_schema` the validator copied itself and the copy then changed its schema-property which would then be reflected in the first validator, that would then continue validation with the subschema, causing the failure as the `required` field wouldn't exist in the higher context.
therefore i changed the code, so a new instance of a validator was used, not a copy. (on that occasion i made sure a child-validator would inherit all `__init__`-parameters unless overwritten.

now the problem is that in cerberus.py#227 a given `context` is always given precedence. which will fail if a subschema is to be validated. but omitting the context (cerberus.py#542) will lead to other failues.

@nicolaiarocci i'd appreciate some advice at this point. especially the code in cerberus.py#227 seems rather strange to me. why would there be a `context`-parameter which always supersedes the `document`-parameter? the calling code could / should figure what is to be validated.