### PR TITLE
Feature anyof

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -712,6 +712,60 @@ Dependencies on sub-document fields are also supported: ::
 
 .. versionadded:: 0.7
 
+anyof
+'''''
+Used to specify a list of rule collections. If the document validates against any one of the rule collections in the list, it is considered valid.
+
+    >>> schema = {"parts": {
+    ...             "type": "list", 
+    ...             "schema": {
+    ...               "type": "dict", 
+    ...               "anyof": [
+    ...                 {
+    ...                   "schema": {
+    ...                     "count": {"type": "integer"}, 
+    ...                     "model number": {"type": "string"}
+    ...                   }
+    ...                 }, 
+    ...                 {
+    ...                   "schema": {
+    ...                     "count": {"type": "integer"}, 
+    ...                     "serial number": {"type": "string"}
+    ...                   }}]}}}
+    >>> document = {"parts": [
+    ...               {
+    ...                 "count": 100, 
+    ...                 "model number": "MX-009"
+    ...               }, 
+    ...               {
+    ...                 "serial number": "898-001"
+    ...               }]}
+    >>> v.validate(document, schema)
+    True
+    >>> document = {"parts": [
+    ...               {
+    ...                 "count": 100, 
+    ...                 "model number": "MX-009"
+    ...               }, 
+    ...               {
+    ...                 "serial number": "898-001"
+    ...               },
+    ...               {
+    ...                 "vin": "98274-0992-K112"
+    ...               }]}
+    >>> v.validate(document, schema)
+    False
+    >>> print v.errors
+    {'parts': {2: {'candidate 0': {'vin number': 'unknown field'}, 'candidate 1': {'vin number': 'unknown field'}}}}
+
+.. versionadded:: 0.9
+
+allof
+'''''
+Same as ``anyof`` except that all rule collections in the list must validate.
+
+.. versionadded:: 0.9
+
 FAQ
 ---
 


### PR DESCRIPTION
Adds an 'anyof' rule that will allow a list of definitions to be given. Currently, all rules in a definition are checked, so a rule is a set of constraints that are AND'ed together. The 'anyof' key allows constraints to be OR'ed. This should work transparently will all existing rules and any user defined validators.

Simple example, taken from unit test
```
# prop1 must be either a number between 0 and 10
schema = {'prop1':  {'min': 0, 'max': 10}}
doc = {'prop1': 5}

self.assertSuccess(doc, schema)

# prop1 must be either a number between 0 and 10 or 100 and 110
schema = {'prop1':
                  {'anyof':
                   [{'min': 0, 'max': 10}, {'min': 100, 'max': 110}]}}
doc = {'prop1': 105}

self.assertSuccess(doc, schema)

# prop1 must be either a number between 0 and 10 or 100 and 110
schema = {'prop1':
                  {'anyof':
                   [{'min': 0, 'max': 10}, {'min': 100, 'max': 110}]}}
doc = {'prop1': 50}

self.assertValidationError(doc, schema)

```

This also satisfies #108. See the [unit test](https://github.com/CD3/cerberus/commit/53c6b72b90bf4827038252a29fc8be4f11a1a938) for the syntax.