### PR TITLE
raises TypeError in case 'value' is a type object

### DIFF
--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -396,7 +396,7 @@ class Validator(object):
                 if constraint == 'type':
                     values = value if isinstance(value, list) else [value]
                     for value in values:
-                        if not hasattr(self, '_validate_type_' + value):
+                        if not hasattr(self, '_validate_type_'.format(value)):
                             raise SchemaError(
                                 errors.ERROR_UNKNOWN_TYPE.format(value))
                     if 'dict' in values and 'list' in values:


### PR DESCRIPTION
small improvement:
if 'value' is a type object, the + concatenation raises a TypeError
'_validate_type_'.format(value) raises no error but still the correct
cerberus.cerberus.SchemaError: unrecognized data-type 'xyz'
is raised.