### PR TITLE
Removes the fallback print-logger

### DIFF
--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -619,12 +619,11 @@ class Validator(object):
         if len(items) != len(values):
             self._error(field, errors.ERROR_ITEMS_LIST.format(len(items)))
         else:
-            for i, item_definition in enumerate(items):
-                validator =\
-                    self.__get_child_validator(schema={i: item_definition})
-                if not validator.validate({i: values[i]}, normalize=False):
-                    self.errors.setdefault(field, {})
-                    self.errors[field].update(validator.errors)
+            schema = dict((i, definition) for i, definition in enumerate(items))  # noqa
+            validator = self.__get_child_validator(schema=schema)
+            if not validator(dict((i, item) for i, item in enumerate(values))):
+                self.errors.setdefault(field, {})
+                self.errors[field].update(validator.errors)
 
     def _validate_items_schema(self, items, field, value):
         validator = self.__get_child_validator(schema=items)

--- a/cerberus/utils.py
+++ b/cerberus/utils.py
@@ -1,19 +1,6 @@
-from __future__ import print_function
 import logging
 
-
-class PrintLogger:
-    @staticmethod
-    def warn(message):
-        print('WARNING cerberus: ' + message)
-
-
-try:
-    log = logging.getLogger('cerberus')
-except:
-    log = PrintLogger
-
-
+log = logging.getLogger('cerberus')
 depr_warnings_printed = {}
 
 


### PR DESCRIPTION
sorry, i messed up. i guess i mistyped when i tested what happens when no logging is setup in the client code. it doesn't raise an exception. thus the fallback-logger wouldn't ever be used.
i don't know a way how to figure out whether the client code actually setup logging and Python's catechism tells us that libraries should just log, all handling is to be configured in the application. i'm fine with that.
shall i add a note to the docs about it?

This commit also slightly improves `items`-validation.