### PR TITLE
Updates of `usage.rst`

### DIFF
--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -713,7 +713,7 @@ class Validator(object):
     def _validate_propertyschema(self, schema, field, value):
         if isinstance(value, Mapping):
             validator = self.__get_child_validator(
-                schema={field: {'type': 'list', 'schema': schema}})
+                schema={field: {'schema': schema}})
             validator.validate({field: list(value.keys())}, normalize=False)
             for error in validator.errors:
                 self._error(field, error)


### PR DESCRIPTION
- more elaborated description of `schema`
- minor docs fixes with regards to content
- use implicit heading-references instead of defined link targets
- text is wrapped to 80 chars
- code is wrapped to 120 chars
- removes documentation of deprecated `items` (list) rule
- removes unnecessary test when validating `propertyschema`


right now i'm hacking a [bootstrap-based theme](https://github.com/ryan-roemer/sphinx-bootstrap-theme) because i was fed up with too thin code blocks in the docs. please shout out a 'halt' if you want to stick with the unresponsive alabaster.