### PR TITLE
bootstrap as theme

### DIFF
--- a/docs/_templates/navbar.html
+++ b/docs/_templates/navbar.html
@@ -1,0 +1,49 @@
+<div id="navbar" class="{{ theme_navbar_class }} navbar-default {% if theme_navbar_fixed_top|tobool -%} navbar-fixed-top{%- endif -%}">
+  <div class="container">
+    <div class="navbar-header">
+      <!-- .btn-navbar is used as the toggle for collapsed navbar content -->
+      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".nav-collapse">
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a class="navbar-brand" href="{{ pathto(master_doc) }}">
+        {%- block sidebarlogo %}
+          {%- if logo %}<img src="{{ pathto('_static/' + logo, 1) }}">{%- endif %}
+        {%- endblock %}
+        {% if theme_navbar_title -%}{{ theme_navbar_title|e }}{%- else -%}{{ project|e }}{%- endif -%}
+      </a>
+      <span class="navbar-text navbar-version pull-left"><b>{{ version|e }}</b></span>
+    </div>
+
+      <div class="collapse navbar-collapse nav-collapse">
+        <ul class="nav navbar-nav">
+          {% block navbartoc %}
+            {% include "globaltoc.html" %}
+            {% if theme_navbar_pagenav %}
+              {% include "navbartoc.html" %}
+            {% endif %}
+          {% endblock %}
+          {% if theme_navbar_links %}
+            {%- for link in theme_navbar_links %}
+              <li><a href="{{ pathto(*link[1:]) }}">{{ link[0] }}</a></li>
+            {%- endfor %}
+          {% endif %}
+          {% if theme_navbar_sidebarrel %}
+            {% block sidebarrel %}
+              {% include "relations.html" %}
+            {% endblock %}
+          {% endif %}
+          {% block navbarextra %}
+          {% endblock %}
+          {% if theme_source_link_position == "nav" %}
+            <li class="hidden-sm">{% include "sourcelink.html" %}</li>
+          {% endif %}
+        </ul>
+
+        {% block navbarsearch %}
+          {% include "navbarsearchbox.html" %}
+        {% endblock %}
+      </div>
+  </div>
+</div>

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,5 +1,3 @@
-.. _api:
-
 API Documentation
 =================
 
@@ -13,6 +11,7 @@ Validator Class
 
 Exceptions
 ----------
+
 .. autoclass:: cerberus.SchemaError
   :members:
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,3 +1,1 @@
-.. _changelog:
-
 .. include:: ../CHANGES

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,13 +12,12 @@
 # serve to show the default.
 
 import sys, os
-import alabaster
+import sphinx_bootstrap_theme
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
-sys.path.append(os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration -----------------------------------------------------
 
@@ -28,7 +27,8 @@ sys.path.append(os.path.abspath('..'))
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
-              'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'alabaster']
+              'sphinx.ext.intersphinx', 'sphinx.ext.todo',
+              'sphinxcontrib.issuetracker']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -45,6 +45,10 @@ master_doc = 'index'
 # General information about the project.
 project = u'Cerberus'
 copyright = u'2012-2015, Nicola Iarocci'
+
+# Settings for `sphinxcontrib.issuetracker`
+issuetracker = 'github'
+issuetracker_project = 'nicolaiarocci/cerberus'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -70,7 +74,7 @@ version = release.split('-dev')[0]
 exclude_patterns = ['_build']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
-#default_role = None
+default_role = 'py'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 #add_function_parentheses = True
@@ -94,95 +98,28 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+html_theme = 'bootstrap'
+
+# Add any paths that contain custom themes here, relative to this directory.
+html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    'logo': 'cerberus.png',
-    'logo_name': True,
-    'logo_text_align': 'center',
-    'github_user': 'nicolaiarocci',
-    'github_repo': 'cerberus',
-    'description': 'Python data validation library',
-    'show_powered_by': False,
-    #'show_related': True,
-    #'travis_button': True,
+    'bootswatch_theme': "flatly",
+    'navbar_site_name': 'Documents',
+    'navbar_pagenav_name': 'Content',
+    'navbar_sidebarrel': False,
+    'navbar_links': [('@PyPI', 'https://pypi.python.org/pypi/Cerberus', True),
+                     ('Source repository', 'https://github.com/nicolaiarocci/cerberus', True)],
+    'source_link_position': "none"
 }
-
-# Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [alabaster.get_path()]
-
-# The name for this set of Sphinx documents.  If None, it defaults to
-# "<project> v<release> documentation".
-html_title = 'Python data validation library'
-
-# A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
-
-# The name of an image file (relative to this directory) to place at the top
-# of the sidebar.
-#html_logo = None
-
-# The name of an image file (within the static path) to use as favicon of the
-# docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
-# pixels large.
-#html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
-
-# If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
-# using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
-
-# If true, SmartyPants will be used to convert quotes and dashes to
-# typographically correct entities.
-#html_use_smartypants = True
-
-# Custom sidebar templates, maps document names to template names.
-html_sidebars = {
-    '**': [
-            'about.html',
-            'navigation.html',
-            'relations.html',
-            'searchbox.html',
-            'donate.html',
-    ]
-}
-
-# Additional templates that should be rendered to pages, maps page names to
-# template names.
-#html_additional_pages = {}
-
-# If false, no module index is generated.
-#html_domain_indices = True
-
-# If false, no index is generated.
-#html_use_index = True
-
-# If true, the index is split into individual pages for each letter.
-#html_split_index = False
-
-# If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
-
-# If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
-
-# If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
-
-# If true, an OpenSearch description file will be output, and all pages will
-# contain a <link> tag referring to it.  The value of this option must be the
-# base URL from which the finished HTML is served.
-#html_use_opensearch = ''
-
-# This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'Cerberusdoc'
@@ -264,7 +201,8 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'py2': ('http://docs.python.org/', None),
+                       'py3': ('http://docs.python.org/3', None)}
 
 
 # -- Options for doclinks extension --------------------------------------------

--- a/docs/contact.rst
+++ b/docs/contact.rst
@@ -1,6 +1,9 @@
 Contact
 =======
-If you’ve scoured the :ref:`prose <usage>` and :ref:`API documentation <api>` and still can’t find an answer to your question, below are various support resources that should help. We do request that you do at least skim the documentation before posting tickets or mailing list questions, however!
+If you’ve scoured the :doc:`prose <usage>` and :doc:`API documentation <api>`
+and still can’t find an answer to your question, below are various support
+resources that should help. We do request that you do at least skim the
+documentation before posting tickets or mailing list questions, however!
 
 If you'd like to stay up to date on the community and development of Cerberus,
 there are several options:
@@ -17,16 +20,16 @@ I often tweet about new features and releases of Cerberus. Follow `@nicolaiarocc
 Mailing List
 ------------
 The `mailing list`_ is intended to be a low traffic resource for users,
-developers and contributors of both the Cerberus and Eve projects. 
+developers and contributors of both the Cerberus and Eve projects.
 
-Bugs/ticket tracker
--------------------
+Issues tracker
+--------------
 To file new bugs or search existing ones, you may visit `Issues`_ page. This
 does require a (free, easy to set up) Github account.
 
 GitHub
 ------
-Of course the best way to track the development of Cerberus is through the 
+Of course the best way to track the development of Cerberus is through the
 `GitHub repo <https://github.com/nicolaiarocci/cerberus>`_.
 
 .. _`mailing list`: https://groups.google.com/forum/#!forum/python-eve

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -69,13 +69,34 @@ to ``tox``:
 
 .. code-block:: console
 
-    # from the project's root directory
+    # in the project's root directory
     $ ./run-docker-tests -e pypy3 -e doctest
 
 You can run the script without any arguments to test the project exactly as
 `Continuous Integration`_ does without having to setup anything.
 If there's a directoy ``.tox`` in the project-folder it will be used to store
 and access cached virtual environments and test-logs.
+
+Building the HTML-documentation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To preview the rendered HTML-documentation you must intially install the
+documentation framework and a theme:
+
+.. code-block:: console
+
+    # in the project's root directory
+    $ pip install -r requirements-docs.txt
+
+The HTML build is triggered with:
+
+.. code-block:: console
+
+    # in 'docs'-folder
+    $ make html
+
+The result can be accessed by opening ``docs/_build/html/index.html``.
+
 
 Continuous Integration
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/customize.rst
+++ b/docs/customize.rst
@@ -1,22 +1,19 @@
 Extending Cerberus
 ==================
 
-Custom Validators
------------------
 Cerberus supports custom validation in two styles:
 
-    * :ref:`class_validator`
-    * :ref:`function_validator`
+    * `Class-based Custom Validators`_
+    * `Function-based Custom Validation`_
 
 As a general rule, when you are customizing validators in your application,
 ``Class-based`` style is more suitable for common validators, which are
 also more human-readable (since the rule name is defined by yourself), while
 ``Function-based`` style is more suitable for special and one-off ones.
 
-.. _class_validator:
 
 Class-based Custom Validators
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------------
 Suppose that in our use case some values can only be expressed as odd integers,
 therefore we decide to add support for a new ``isodd`` rule to our validation
 schema:
@@ -80,7 +77,8 @@ use a pattern like this:
 Custom Data Types
 ~~~~~~~~~~~~~~~~~
 Cerberus supports and validates several standard data types (see :ref:`type`).
-When building :ref:`class_validator` you can add and validate your own data types.
+When building a `Class-based Custom Validators`_ you can add and validate your
+own data types.
 For example `Eve <http://python-eve.org>`_ (a tool for quickly building and
 deploying RESTful Web Services) supports a custom ``objectid`` type, which is
 used to validate that field values conform to the BSON/MongoDB ``ObjectId``
@@ -104,10 +102,9 @@ has been implemented:
 
 .. versionadded:: 0.0.2
 
-.. _function_validator:
 
 Function-based Custom Validation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------
 With a special rule ``validator``, you can customize validators by defining
 your own functions with the following prototype: ::
 
@@ -140,17 +137,18 @@ Then, you can validate an odd value like this:
 
 .. versionadded:: 0.8
 
-Limitations
-~~~~~~~~~~~
 
+Limitations
+-----------
 You must not call your custom rule ``validator`` and it may be a bad idea to
 overwrite particular contributed rules.
 
-Relevant `Validator`-properties
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Relevant `Validator`-attributes
+-------------------------------
 
 `Validator.__get_child_validator`
-.................................
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you need another instance of your ``Validator``-subclass, the
 ``__get_child_validator``-method returns another instance that is initiated
@@ -160,7 +158,7 @@ arguments.
 .. versionadded:: 0.9
 
 `Validator.root_document`
-.........................
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A child-validator - as used when validating a ``schema`` - can access the first
 generation validator's document that is being processed via its

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,9 +1,7 @@
 Frequently Asked Questions
 ==========================
 
-Can I use Cerberus to validate objectis?
-----------------------------------------
+Can I use Cerberus to validate objects?
+---------------------------------------
 
-Yes. See `Validating user objects with Cerberus`_.
-
-.. _`Validating user objects with Cerberus`: http://nicolaiarocci.com/validating-user-objects-cerberus/
+Yes. See `Validating user objects with Cerberus <http://nicolaiarocci.com/validating-user-objects-cerberus/>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,9 @@
 Welcome to Cerberus
 ===================
 
+.. image:: _static/cerberus.png
+   :align: right
+
 Cerberus is a lightweight and extensible data validation library for
 Python.
 
@@ -22,7 +25,7 @@ You define a validation schema and pass it to an instance of the
     >>> schema = {'name': {'type': 'string'}}
     >>> v = Validator(schema)
 
-Then you simply invoke the :func:`~cerberus.Validator.validate` to validate
+Then you simply invoke the :meth:`~cerberus.Validator.validate` to validate
 a dictionary against the schema. If validation succeeds, ``True`` is returned:
 
 ::
@@ -35,8 +38,10 @@ Table of Contents
 -----------------
 .. toctree::
 
-    Installing <install>
+    Installation <install>
     Usage <usage>
+    Validation Rules <validation-rules>
+    Normalization Rules <normalization-rules>
     Extending <customize>
     Contributing <contribute>
     API <api>
@@ -52,4 +57,3 @@ Cerberus is an open source project by `Nicola Iarocci
 <http://nicolaiarocci.com>`_. See the original `LICENSE
 <https://github.com/nicolaiarocci/cerberus/blob/master/LICENSE>`_ for more
 information.
-

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,14 +1,17 @@
 Cerberus Installation
 =====================
+
 This part of the documentation covers the installation of Cerberus. The first
 step to using any software package is getting it properly installed.
 
 Stable Version
 --------------
 Cerberus is on `PyPI <https://pypi.python.org/pypi/Cerberus>`_ so all you need
-to do is: ::
+to do is:
 
-    pip install cerberus
+.. code-block:: console
+
+    $ pip install cerberus
 
 Development Version
 -------------------

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,8 +1,6 @@
-.. _license:
-  
 License
 =======
 Cerberus is an open source project by `Nicola Iarocci
-<http://nicolaiarocci.com>`_. 
+<http://nicolaiarocci.com>`_.
 
 .. include:: ../LICENSE

--- a/docs/normalization-rules.rst
+++ b/docs/normalization-rules.rst
@@ -1,0 +1,65 @@
+Normalization Rules
+===================
+
+Renaming Of Fields
+------------------
+You can define a field to be renamed before any further processing.
+
+.. doctest::
+
+   >>> v = Validator({'foo': {'rename': 'bar'}})
+   >>> v.normalized({'foo': 0})
+   {'bar': 0}
+
+To let a callable rename a field or arbitrary fields, you can define a handler
+for renaming:
+
+.. doctest::
+
+   >>> v = Validator({}, allow_unknown={'rename_handler': int})
+   >>> v.normalized({'0': 'foo'})
+   {0: 'foo'}
+
+Purging Unknown Fields
+----------------------
+After renaming, unknown fields will be purged if the
+:attr:`~cerberus.Validator.purge_unknown` property of a
+:class:`~cerberus.Validator` instance is ``True``; it defaults to ``False``.
+You can set the property per keyword-argument upon initialization or as rule for
+subdocuments like :ref:`allow_unknown <allow_unknown-rule>`. The default is
+``False``.
+
+.. doctest::
+
+   >>> v = Validator({'foo': {'type': 'string'}}, purge_unknown=True)
+   >>> v.normalized({'bar': 'foo'})
+   {}
+
+.. _type-coercion:
+
+Value Coercion
+--------------
+Coercion allows you to apply a callable to a value before the document is validated.
+The return value of the callable replaces the new value in the document. This can be
+used to convert values or sanitize data before it is validated.
+
+.. doctest::
+
+   >>> v.schema = {'amount': {'type': 'integer'}}
+   >>> v.validate({'amount': '1'})
+   False
+
+   >>> v.schema = {'amount': {'type': 'integer', 'coerce': int}}
+   >>> v.validate({'amount': '1'})
+   True
+   >>> v.document
+   {'amount': 1}
+
+   >>> to_bool = lambda v: v.lower() in ['true', '1']
+   >>> v.schema = {'flag': {'type': 'boolean', 'coerce': to_bool}}
+   >>> v.validate({'flag': 'true'})
+   True
+   >>> v.document
+   {'flag': True}
+
+.. versionadded:: 0.9

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -88,6 +88,8 @@ See :doc:`validation-rules` and :doc:`normalization-rules` for an extensive
 documentation of all supported rules.
 
 
+.. _allowing-the-unknown:
+
 Allowing the Unknown
 --------------------
 By default only keys defined in the schema are allowed:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,5 +1,3 @@
-.. _usage:
-
 Cerberus Usage
 ==============
 
@@ -13,7 +11,7 @@ You define a validation schema and pass it to an instance of the
     >>> schema = {'name': {'type': 'string'}}
     >>> v = Validator(schema)
 
-Then you simply invoke the :func:`~cerberus.Validator.validate` to validate
+Then you simply invoke the :meth:`~cerberus.Validator.validate` to validate
 a dictionary against the schema. If validation succeeds, ``True`` is returned:
 
 .. testsetup::
@@ -29,7 +27,7 @@ a dictionary against the schema. If validation succeeds, ``True`` is returned:
     True
 
 Alternatively, you can pass both the dictionary and the schema to the
-:func:`~cerberus.Validator.validate` method:
+:meth:`~cerberus.Validator.validate` method:
 
 .. doctest::
 
@@ -54,8 +52,8 @@ the first validation issue. The whole document will always be processed, and
     >>> v.errors
     {'age': 'min value is 10'}
 
-You will still get :class:`~cerberus.SchemaError` and
-:class:`~cerberus.DocumentError` exceptions.
+You will still get :exc:`~cerberus.SchemaError` and
+:exc:`~cerberus.DocumentError` exceptions.
 
 .. versionchanged:: 0.4.1
     The Validator class is callable, allowing for the following shorthand
@@ -83,590 +81,11 @@ which is expected to be a string not longer than 10 characters. Something like
 ``{'name': 'john doe'}`` would validate, while something like ``{'name': 'a
 very long string'}`` or ``{'name': 99}`` would not.
 
-By definition all keys are optional unless the `required`_ rule is set for
+By definition all keys are optional unless the :ref:`required`-rule is set for
 a key.
 
-
-Validation Rules
-----------------
-The following rules are currently supported:
-
-.. _type:
-
-type
-~~~~
-Data type allowed for the key value. Can be one of the following:
-    * ``string``
-    * ``integer``
-    * ``float``
-    * ``number`` (integer or float)
-    * ``boolean``
-    * ``datetime``
-    * ``dict`` (formally ``collections.mapping``)
-    * ``list`` (formally ``collections.sequence``, excluding strings)
-    * ``set``
-
-A list of types can be used to allow different values:
-
-.. doctest::
-
-    >>> v.schema = {'quotes': {'type': ['string', 'list']}}
-    >>> v.validate({'quotes': 'Hello world!'})
-    True
-    >>> v.validate({'quotes': ['Do not disturb my circles!', 'Heureka!']})
-    True
-
-.. doctest::
-
-    >>> v.schema = {'quotes': {'type': ['string', 'list'], 'schema': {'type': 'string'}}}
-    >>> v.validate({'quotes': 'Hello world!'})
-    True
-    >>> v.validate({'quotes': [1, 'Heureka!']})
-    False
-    >>> v.errors
-    {'quotes': {0: 'must be of string type'}}
-
-You can extend this list and support custom types, see :ref:`new-types`.
-
-.. note::
-
-    Please note that type validation is performed before most others which
-    exist for the same field (only `nullable`_ and `readonly`_ are considered
-    beforehand). In the occurrence of a type failure subsequent validation
-    rules on the field will be skipped and validation will continue on other
-    fields. This allows to safely assume that field type is correct when other
-    (standard or custom) rules are invoked.
-
-.. versionchanged:: 0.9
-   If a list of types is given, the key value must match *any* of them.
-
-.. versionchanged:: 0.7.1
-   ``dict`` and ``list`` typechecking are now performed with the more generic
-   ``Mapping`` and ``Sequence`` types from the builtin ``collections`` module.
-   This means that instances of custom types designed to the same interface as
-   the builtin ``dict`` and ``list`` types can be validated with Cerberus. We
-   exclude strings when type checking for ``list``/``Sequence`` because it
-   in the validation situation it is almost certain the string was not the
-   intended data type for a sequence.
-
-.. versionchanged:: 0.7
-   Added the ``set`` data type.
-
-.. versionchanged:: 0.6
-   Added the ``number`` data type.
-
-.. versionchanged:: 0.4.0
-   Type validation is always executed first, and blocks other field validation
-   rules on failure.
-
-.. versionchanged:: 0.3.0
-   Added the ``float`` data type.
-
-required
-~~~~~~~~
-If ``True`` the key/value pair is mandatory. Validation will fail when it is
-missing, unless :func:`~cerberus.Validator.validate` is called with
-``update=True``:
-
-.. doctest::
-
-    >>> v.schema = {'name': {'required': True, 'type': 'string'}, 'age': {'type': 'integer'}}
-    >>> document = {'age': 10}
-    >>> v.validate(document)
-    False
-    >>> v.errors
-    {'name': 'required field'}
-
-    >>> v.validate(document, update=True)
-    True
-
-.. note::
-
-   String fields with empty values will still be validated, even when
-   ``required`` is set to ``True``. If you don't want to accept empty values,
-   see the empty_ rule. Also, if dependencies_ are declared for the field, its
-   ``required`` rule will only be validated if all dependencies are
-   included with the document.
-
-.. versionchanged:: 0.8
-   Check field dependencies.
-
-readonly
-~~~~~~~~
-If ``True`` the value is readonly. Validation will fail if this field is present
-in the target dictionary.
-
-nullable
-~~~~~~~~
-If ``True`` the field value can be set to ``None``. It is essentially the
-functionality of the ``ignore_none_values`` parameter of the :ref:`validator`,
-but allowing for more fine grained control down to the field level.
-
-.. doctest::
-
-    >>> v.schema = {'a_nullable_integer': {'nullable': True, 'type': 'integer'}, 'an_integer': {'type': 'integer'}}
-
-    >>> v.validate({'a_nullable_integer': 3})
-    True
-    >>> v.validate({'a_nullable_integer': None})
-    True
-
-    >>> v.validate({'an_integer': 3})
-    True
-    >>> v.validate({'an_integer': None})
-    False
-    >>> v.errors
-    {'an_integer': 'null value not allowed'}
-
-.. versionchanged:: 0.7 ``nullable`` is valid on fields lacking type definition.
-.. versionadded:: 0.3.0
-
-minlength, maxlength
-~~~~~~~~~~~~~~~~~~~~
-Minimum and maximum length allowed for ``string`` and ``list`` types.
-
-min, max
-~~~~~~~~
-Minimum and maximum value allowed for ``integer``, ``float`` and ``number``
-types.
-
-.. versionchanged:: 0.7
-   Added support for ``float`` and ``number`` types.
-
-allowed
-~~~~~~~
-Allowed values for ``string``, ``list`` and ``int`` types. Validation will fail
-if target values are not included in the allowed list.
-
-.. doctest::
-
-    >>> v.schema = {'role': {'type': 'list', 'allowed': ['agent', 'client', 'supplier']}}
-    >>> v.validate({'role': ['agent', 'supplier']})
-    True
-
-    >>> v.validate({'role': ['intern']})
-    False
-    >>> v.errors
-    {'role': "unallowed values ['intern']"}
-
-    >>> v.schema = {'role': {'type': 'string', 'allowed': ['agent', 'client', 'supplier']}}
-    >>> v.validate({'role': 'supplier'})
-    True
-
-    >>> v.validate({'role': 'intern'})
-    False
-    >>> v.errors
-    {'role': 'unallowed value intern'}
-
-    >>> v.schema = {'a_restricted_integer': {'type': 'integer', 'allowed': [-1, 0, 1]}}
-    >>> v.validate({'a_restricted_integer': -1})
-    True
-
-    >>> v.validate({'a_restricted_integer': 2})
-    False
-    >>> v.errors
-    {'a_restricted_integer': 'unallowed value 2'}
-
-.. versionchanged:: 0.5.1
-   Added support for the ``int`` type.
-
-empty
-~~~~~
-Only applies to string fields. If ``False`` validation will fail if the value
-is empty. Defaults to ``True``.
-
-.. doctest::
-
-    >>> schema = {'name': {'type': 'string', 'empty': False}}
-    >>> document = {'name': ''}
-    >>> v.validate(document, schema)
-    False
-
-    >>> v.errors
-    {'name': 'empty values not allowed'}
-
-.. versionadded:: 0.0.3
-
-items (dict)
-~~~~~~~~~~~~
-.. deprecated:: 0.0.3
-   Use `schema (dict)`_ instead.
-
-items (list)
-~~~~~~~~~~~~
-When a list, ``items`` defines a list of values allowed in a ``list`` type of
-fixed length in the given order:
-
-.. doctest::
-
-    >>> schema = {'list_of_values': {'type': 'list', 'items': [{'type': 'string'}, {'type': 'integer'}]}}
-    >>> document = {'list_of_values': ['hello', 100]}
-    >>> v.validate(document, schema)
-    True
-    >>> document = {'list_of_values': [100, 'hello']}
-    >>> v.validate(document, schema)
-    False
-
-See `schema (list)`_ rule below for dealing with arbitrary length ``list`` types.
-
-schema (dict)
-~~~~~~~~~~~~~
-If a field for which a ``schema``-rule is defined has a *mapping* as value,
-that mapping will be validated against the schema that is provided as
-constraint.
-
-.. doctest::
-
-    >>> schema = {'a_dict': {'type': 'dict', 'schema': {'address': {'type': 'string'},
-    ...                                                 'city': {'type': 'string', 'required': True}}}}
-    >>> document = {'a_dict': {'address': 'my address', 'city': 'my town'}}
-    >>> v.validate(document, schema)
-    True
-
-.. note::
-
-    To validate *arbitrary keys* of a mapping, see `propertyschema`_, resp.
-    `valueschema`_ for *arbitrary values* of a mapping.
-
-schema (list)
-~~~~~~~~~~~~~
-If ``schema``-validation encounters an arbritrary sized *sequence* as value,
-all items of the sequence will be validated against the rules provided in
-``schema``'s constraint.
-
-.. doctest::
-
-    >>> schema = {'a_list': {'type': 'list', 'schema': {'type': 'integer'}}}
-    >>> document = {'a_list': [3, 4, 5]}
-    >>> v.validate(document, schema)
-    True
-
-The `schema` rule on ``list`` types is also the preferred method for defining
-and validating a list of dictionaries.
-
-.. doctest::
-
-    >>> schema = {'rows': {'type': 'list',
-    ...                    'schema': {'type': 'dict', 'schema': {'sku': {'type': 'string'},
-    ...                                                          'price': {'type': 'integer'}}}}}
-    >>> document = {'rows': [{'sku': 'KT123', 'price': 100}]}
-    >>> v.validate(document, schema)
-    True
-
-.. versionchanged:: 0.0.3
-   Schema rule for ``list`` types of arbitrary length
-
-valueschema
-~~~~~~~~~~~
-Validation schema for all values of a ``dict``. The ``dict`` can have arbitrary
-keys, the values for all of which must validate with given schema:
-
-.. doctest::
-
-    >>> schema = {'numbers': {'type': 'dict', 'valueschema': {'type': 'integer', 'min': 10}}}
-    >>> document = {'numbers': {'an integer': 10, 'another integer': 100}}
-    >>> v.validate(document, schema)
-    True
-
-    >>> document = {'numbers': {'an integer': 9}}
-    >>> v.validate(document, schema)
-    False
-
-    >>> v.errors
-    {'numbers': {'an integer': 'min value is 10'}}
-
-.. versionadded:: 0.7
-.. versionchanged:: 0.9
-   renamed ``keyschema`` to ``valueschema``
-
-propertyschema
-~~~~~~~~~~~~~~
-
-This is the counterpart to ``valueschema`` that validates the `keys` of a
-``dict``. For historical reasons it is `not` named ``keyschema``.
-
-.. doctest::
-
-    >>> schema = {'a_dict': {'type': 'dict', 'propertyschema': {'type': 'string', 'regex': '[a-z]+'}}}
-    >>> document = {'a_dict': {'key': 'value'}}
-    >>> v.validate(document, schema)
-    True
-
-    >>> document = {'a_dict': {'KEY': 'value'}}
-    >>> v.validate(document, schema)
-    False
-
-.. versionadded:: 0.9
-
-regex
-~~~~~
-Validation will fail if field value does not match the provided regex rule.
-Only applies to string fiels.
-
-.. doctest::
-
-    >>> schema = {'email': {'type': 'string', 'regex': '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$'}}
-    >>> document = {'email': 'john@example.com'}
-    >>> v.validate(document, schema)
-    True
-
-    >>> document = {'email': 'john_at_example_dot_com'}
-    >>> v.validate(document, schema)
-    False
-
-    >>> v.errors
-    {'email': "value does not match regex '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$'"}
-
-For details on regex rules, see `Regular Expressions Syntax`_ in Python's documentation.
-
-.. versionadded:: 0.7
-
-dependencies
-~~~~~~~~~~~~
-This rule allows for either a list or dict of dependencies. When a list is
-provided, all listed fields must be present in order for the target field to be
-validated.
-
-.. doctest::
-
-    >>> schema = {'field1': {'required': False}, 'field2': {'required': False, 'dependencies': ['field1']}}
-    >>> document = {'field1': 7}
-    >>> v.validate(document, schema)
-    True
-
-    >>> document = {'field2': 7}
-    >>> v.validate(document, schema)
-    False
-
-    >>> v.errors
-    {'field2': "field 'field1' is required"}
-
-When a dictionary is provided, then not only all dependencies must be present,
-but also any of their allowed values must be matched.
-
-.. doctest::
-
-    >>> schema = {'field1': {'required': False},
-    ...           'field2': {'required': True, 'dependencies': {'field1': ['one', 'two']}}}
-
-    >>> document = {'field1': 'one', 'field2': 7}
-    >>> v.validate(document, schema)
-    True
-
-    >>> document = {'field1': 'three', 'field2': 7}
-    >>> v.validate(document, schema)
-    False
-    >>> v.errors
-    {'field2': "field 'field1' is required with one of these values: ['one', 'two']"}
-
-    >>> # same as using a dependencies list
-    >>> document = {'field2': 7}
-    >>> v.validate(document, schema)
-    False
-    >>> v.errors
-    {'field2': "field 'field1' is required with one of these values: ['one', 'two']"}
-
-    >>> # one can also pass a single dependency value
-    >>> schema = {'field1': {'required': False}, 'field2': {'dependencies': {'field1': 'one'}}}
-    >>> document = {'field1': 'one', 'field2': 7}
-    >>> v.validate(document, schema)
-    True
-
-    >>> document = {'field1': 'two', 'field2': 7}
-    >>> v.validate(document, schema)
-    False
-
-    >>> v.errors
-    {'field2': "field 'field1' is required with one of these values: ['one']"}
-
-Dependencies on sub-document fields are also supported:
-
-.. doctest::
-
-    >>> schema = {
-    ...   'test_field': {'dependencies': ['a_dict.foo', 'a_dict.bar']},
-    ...   'a_dict': {
-    ...     'type': 'dict',
-    ...     'schema': {
-    ...       'foo': {'type': 'string'},
-    ...       'bar': {'type': 'string'}
-    ...     }
-    ...   }
-    ... }
-
-    >>> document = {'test_field': 'foobar', 'a_dict': {'foo': 'foo'}}
-    >>> v.validate(document, schema)
-    False
-
-    >>> v.errors
-    {'test_field': "field 'a_dict.bar' is required"}
-
-.. versionchanged:: 0.8.1 Support for sub-document fields as dependencies.
-
-.. versionchanged:: 0.8 Support for dependencies as a dictionary.
-
-.. versionadded:: 0.7
-
-\*of-rules
-~~~~~~~~~~
-
-These rules allow you to list multiple sets of rules to validate against. The
-field will be considered valid if it validates against the set in the list
-according to the prefixes logics ``all``, ``any``, ``one`` or ``none``.
-
-.. versionadded:: 0.9
-
-
-anyof
-.....
-
-Validates if *any* of the provided constraints validates the field.
-
-allof
-.....
-
-Validates if *all* of the provided constraints validates the field.
-
-noneof
-......
-
-Validates if *none* of the provided constraints validates the field.
-
-oneof
-.....
-
-Validates if *exactly one* of the provided constraints applies.
-
-For example, to verify that a property is a number between 0 and 10 or 100 and
-110, you could do the following:
-
-.. doctest::
-
-    >>> schema = {'prop1':
-    ...           {'type': 'number',
-    ...            'anyof':
-    ...            [{'min': 0, 'max': 10}, {'min': 100, 'max': 110}]}}
-
-    >>> document = {'prop1': 5}
-    >>> v.validate(document, schema)
-    True
-
-    >>> document = {'prop1': 105}
-    >>> v.validate(document, schema)
-    True
-
-    >>> document = {'prop1': 55}
-    >>> v.validate(document, schema)
-    False
-    >>> v.errors   # doctest: +SKIP
-    {'prop1': {'anyof': 'no definitions validated', 'definition 1': 'min value is 100', 'definition 0': 'max value is 10'}}
-
-The ``anyof`` rule works by creating a new instance of a schema for each item
-in the list. The above schema is equivalent to creating two separate schemas:
-
-.. doctest::
-
-    >>> schema1 = {'prop1': {'type': 'number', 'min':   0, 'max':  10}}
-    >>> schema2 = {'prop1': {'type': 'number', 'min': 100, 'max': 110}}
-
-    >>> document = {'prop1': 5}
-    >>> v.validate(document, schema1) or v.validate(document, schema2)
-    True
-
-    >>> document = {'prop1': 105}
-    >>> v.validate(document, schema1) or v.validate(document, schema2)
-    True
-
-    >>> document = {'prop1': 55}
-    >>> v.validate(document, schema1) or v.validate(document, schema2)
-    False
-
-\*of-rules typesaver
-....................
-
-You can concatenate any of-rule with an underscore and another rule with a
-list of rule-values to save typing:
-
-.. testcode::
-
-    {'foo': {'anyof_type': ['string', 'integer']}}
-    # is equivalent to
-    {'foo': {'anyof': [{'type': 'string'}, {'type': 'integer'}]}}
-
-Thus you can use this to validate a document against several schemas without
-implementing your own logic:
-
-.. testsetup::
-
-    employees = ()
-
-.. doctest::
-
-    >>> schemas = [{'department': {'required': True, 'regex': '^IT$'}, 'phone': {'nullable': True}},
-    ...            {'department': {'required': True}, 'phone': {'required': True}}]
-    >>> emloyee_vldtr = Validator({'employee': {'oneof_schema': schemas, 'type': 'dict'}}, allow_unknown=True)
-    >>> invalid_employees_phones = []
-    >>> for employee in employees:
-    ...     if not employee_vldtr.validate(employee):
-    ...         invalid_employees_phones.append(employee)
-
-.. versionadded: 0.10
-
-
-excludes
-~~~~~~~~
-
-You can declare fields to excludes others:
-
-.. doctest::
-
-    >>> v = Validator()
-    >>> schema = {'this_field': {'type': 'dict',
-    ...                          'excludes': 'that_field'},
-    ...           'that_field': {'type': 'dict',
-    ...                          'excludes': 'this_field'}}
-    >>> v.validate({'this_field': {}, 'that_field': {}}, schema)
-    False
-    >>> v.validate({'this_field': {}}, schema)
-    True
-    >>> v.validate({'that_field': {}}, schema)
-    True
-    >>> v.validate({}, schema)
-    True
-
-
-You can require both field to build an exclusive `or`:
-
-.. doctest::
-
-    >>> v = Validator()
-    >>> schema = {'this_field': {'type': 'dict',
-    ...                          'excludes': 'that_field',
-    ...                          'required': True},
-    ...           'that_field': {'type': 'dict',
-    ...                          'excludes': 'this_field',
-    ...                          'required': True}}
-    >>> v.validate({'this_field': {}, 'that_field': {}}, schema)
-    False
-    >>> v.validate({'this_field': {}}, schema)
-    True
-    >>> v.validate({'that_field': {}}, schema)
-    True
-    >>> v.validate({}, schema)
-    False
-
-
-You can also pass multiples fields to exclude in a list :
-
-.. doctest::
-
-   >>> schema = {'this_field': {'type': 'dict',
-   ...                          'excludes': ['that_field', 'bazo_field']},
-   ...           'that_field': {'type': 'dict',
-   ...                          'excludes': 'this_field'},
-   ...           'bazo_field': {'type': 'dict'}}
-   >>> v.validate({'this_field': {}, 'bazo_field': {}}, schema)
-   False
+See :doc:`validation-rules` and :doc:`normalization-rules` for an extensive
+documentation of all supported rules.
 
 
 Allowing the Unknown
@@ -682,7 +101,7 @@ By default only keys defined in the schema are allowed:
     {'sex': 'unknown field'}
 
 However, you can allow unknown key/value pairs by either setting
-``allow_unknown`` to ``True``:
+:attr:`~Cerberus.Validator.allow_unknown` to ``True``:
 
 .. doctest::
 
@@ -691,8 +110,8 @@ However, you can allow unknown key/value pairs by either setting
     >>> v.validate({'name': 'john', 'sex': 'M'})
     True
 
-Or you can set ``allow_unknown`` to a validation schema, in which case
-unknown fields will be validated against it:
+Or you can set :attr:`~Cerberus.Validator.allow_unknown` to a validation
+schema, in which case unknown fields will be validated against it:
 
 .. doctest::
 
@@ -705,17 +124,19 @@ unknown fields will be validated against it:
     >>> v.errors
     {'an_unknown_field': 'must be of string type'}
 
-``allow_unknown`` can also be set at initialization:
+:attr:`~Cerberus.Validator.allow_unknown` can also be set at initialization:
 
 .. doctest::
 
-    >>> v.schema = {}
-    >>> v.allow_unknown = True
+    >>> v = Validator({}, allow_unknown=True)
     >>> v.validate({'name': 'john', 'sex': 'M'})
     True
+    >>> v.allow_unknown = False
+    >>> v.validate({'name': 'john', 'sex': 'M'})
+    False
 
 ``allow_unknown`` can also be set as rule to configure a validator for a nested
-mapping that is checked against the ``schema``-rule:
+mapping that is checked against the :ref:`schema <schema_dict-rule>` rule:
 
 .. doctest::
 
@@ -745,88 +166,24 @@ mapping that is checked against the ``schema``-rule:
     {'an_unknown_field': 'unknown field'}
 
 .. versionchanged:: 0.9
-   ``allow_unknown`` can also be set for nested dict fields.
+   :attr:`~Cerberus.Validator.allow_unknown` can also be set for nested dict fields.
 
 .. versionchanged:: 0.8
-   ``allow_unknown`` can also be set to a validation schema.
+   :attr:`~Cerberus.Validator.allow_unknown` can also be set to a validation schema.
 
-.. _type-coercion:
-
-
-Normalization Rules
--------------------
-
-Renaming Of Fields
-~~~~~~~~~~~~~~~~~~
-You can define a field to be renamed before any further processing.
-
-.. doctest::
-
-    >>> v = Validator({'foo': {'rename': 'bar'}})
-    >>> v.normalized({'foo': 0})
-    {'bar': 0}
-
-To let a callable rename a field or arbitrary fields, you can define a handler
-for renaming:
-
-.. doctest::
-
-    >>> v = Validator({}, allow_unknown={'rename_handler': int})
-    >>> v.normalized({'0': 'foo'})
-    {0: 'foo'}
-
-Purging Unknown Fields
-~~~~~~~~~~~~~~~~~~~~~~
-
-After renaming, unknown fields will be purged if the ``purge_unknown``-property of
-a ``Validator``-instance is ``True``.
-You can set the property per keyword-argument upon initialization or as rule for
-subdocuments like ``allow_unknown``. The default is ``False``.
-
-.. doctest::
-
-    >>> v = Validator({'foo': {'type': 'string'}}, purge_unknown=True)
-    >>> v.normalized({'bar': 'foo'})
-    {}
-
-Value Coercion
-~~~~~~~~~~~~~~
-Coercion allows you to apply a callable to a value before the document is validated.
-The return value of the callable replaces the new value in the document. This can be
-used to convert values or sanitize data before it is validated.
-
-.. doctest::
-
-    >>> v.schema = {'amount': {'type': 'integer'}}
-    >>> v.validate({'amount': '1'})
-    False
-
-    >>> v.schema = {'amount': {'type': 'integer', 'coerce': int}}
-    >>> v.validate({'amount': '1'})
-    True
-    >>> v.document
-    {'amount': 1}
-
-    >>> to_bool = lambda v: v.lower() in ['true', '1']
-    >>> v.schema = {'flag': {'type': 'boolean', 'coerce': to_bool}}
-    >>> v.validate({'flag': 'true'})
-    True
-    >>> v.document
-    {'flag': True}
-
-.. versionadded:: 0.9
 
 Fetching Processed Documents
 ----------------------------
 
-Beside the ``document``-property a ``Validator``-instance has shorthand methods
-to process a document and fetch its processed result.
+Beside the :attr:`~cerberus.Validator.document` property a :class:`Validator`
+instance has shorthand methods to process a document and fetch its processed
+result.
 
 `validated` Method
 ~~~~~~~~~~~~~~~~~~
-There's a wrapper-method ``validated`` that returns the validated document. If
-the document didn't validate ``None`` is returned. It can be useful for flows
-like this:
+There's a wrapper-method :meth:`~cerberus.Validator.validated` that returns the
+validated document. If the document didn't validate ``None`` is returned. It
+can be useful for flows like this:
 
 .. testsetup::
 
@@ -837,7 +194,7 @@ like this:
     v = Validator(schema)
     valid_documents = [x for x in [v.validated(y) for y in documents] if x is not None]
 
-If a coercion callable raises a ``TypeError`` or ``ValueError`` then the
+If a coercion callable raises a :exc:`TypeError` or :exc:`ValueError` then the
 exception will be caught and the validation with fail.  All other exception
 pass through.
 
@@ -845,8 +202,8 @@ pass through.
 
 `normalized` Method
 ~~~~~~~~~~~~~~~~~~~
-Similary, the ``normalized``-method returns a normalized copy of a document
-without validating it:
+Similary, the :meth:`~cerberus.Validator.normalized` method returns a
+normalized copy of a document without validating it:
 
 .. doctest::
 
@@ -862,10 +219,10 @@ without validating it:
 Schema Definition Formats
 -------------------------
 
-Cerberus schemas are built with vanilla Python types: ``dict``, ``list``,
-``string``, etc. Even user-defined validation rules are invoked in the schema
-by name, as a string. A useful side effect of this design is that schemas can
-be defined in a number of ways, for example with PyYAML_.
+Cerberus schemas are built with vanilla Python types: :class:`dict`,
+:class:`list`, ``strings``, etc. Even user-defined validation rules are
+invoked in the schema by name, as a string. A useful side effect of this design
+is that schemas can be defined in a number of ways, for example with PyYAML_.
 
 .. doctest::
 
@@ -885,9 +242,8 @@ be defined in a number of ways, for example with PyYAML_.
     {'age': 'min value is 10'}
 
 You don't have to use YAML of course, you can use your favorate serializer.
-JSON for example. As long as there is a decoder thant can produce a nested
-``dict``, you can use it to define a schema.
+JSON for example. As long as there is a decoder that can produce a nested
+:class:`dict`, you can use it to define a schema.
 
 
 .. _PyYAML: http://pyyaml.org
-.. _`Regular Expressions Syntax`: https://docs.python.org/library/re.html#regular-expression-syntax

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -1,6 +1,14 @@
 Validation Rules
 ================
 
+allow_unknown
+-------------
+This can be used in conjunction with the  `schema <schema_dict-rule>`_ rule
+when validating a mapping in order to set the
+:attr:`~cerberus.Validator.allow_unknown` property of the validator for the
+subdocument.
+For a full alaboration refer to :ref:`this paragraph <allowing-the-unknown>`.
+
 allowed
 -------
 Allowed values for ``string``, ``list`` and ``int`` types. Validation will fail

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -1,0 +1,596 @@
+Validation Rules
+================
+
+.. _type:
+
+type
+----
+Data type allowed for the key value. Can be one of the following names:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Type Name
+     - Python 2 Type
+     - Python 3 Type
+   * - ``boolean``
+     - :class:`bool`
+     - :class:`bool`
+   * - ``datetime``
+     - :class:`datetime.datetime`
+     - :class:`datetime.datetime`
+   * - ``dict``
+     - :class:`collections.Mapping`
+     - :class:`collections.Mapping`
+   * - ``float``
+     - :class:`float`
+     - :class:`float`
+   * - ``integer``
+     - :class:`int`, :class:`long`
+     - :class:`int`
+   * - ``list``
+     - :class:`collections.Sequence`, excl. strings
+     - :class:`collections.Sequence`, excl. strings
+   * - ``number``
+     - :class:`float`, :class:`int`, :class:`long`
+     - :class:`float`, :class:`int`
+   * - ``set``
+     - :class:`set`
+     - :class:`set`
+   * - ``string``
+     - :class:`basestring`
+     - :class:`str`
+
+You can extend this list and support :ref:`custom types <new-types>`.
+
+A list of types can be used to allow different values:
+
+.. doctest::
+
+    >>> v.schema = {'quotes': {'type': ['string', 'list']}}
+    >>> v.validate({'quotes': 'Hello world!'})
+    True
+    >>> v.validate({'quotes': ['Do not disturb my circles!', 'Heureka!']})
+    True
+
+.. doctest::
+
+    >>> v.schema = {'quotes': {'type': ['string', 'list'], 'schema': {'type': 'string'}}}
+    >>> v.validate({'quotes': 'Hello world!'})
+    True
+    >>> v.validate({'quotes': [1, 'Heureka!']})
+    False
+    >>> v.errors
+    {'quotes': {0: 'must be of string type'}}
+
+.. note::
+
+    Please note that type validation is performed before most others which
+    exist for the same field (only `nullable`_ and `readonly`_ are considered
+    beforehand). In the occurrence of a type failure subsequent validation
+    rules on the field will be skipped and validation will continue on other
+    fields. This allows to safely assume that field type is correct when other
+    (standard or custom) rules are invoked.
+
+.. versionchanged:: 0.9
+   If a list of types is given, the key value must match *any* of them.
+
+.. versionchanged:: 0.7.1
+   ``dict`` and ``list`` typechecking are now performed with the more generic
+   ``Mapping`` and ``Sequence`` types from the builtin ``collections`` module.
+   This means that instances of custom types designed to the same interface as
+   the builtin ``dict`` and ``list`` types can be validated with Cerberus. We
+   exclude strings when type checking for ``list``/``Sequence`` because it
+   in the validation situation it is almost certain the string was not the
+   intended data type for a sequence.
+
+.. versionchanged:: 0.7
+   Added the ``set`` data type.
+
+.. versionchanged:: 0.6
+   Added the ``number`` data type.
+
+.. versionchanged:: 0.4.0
+   Type validation is always executed first, and blocks other field validation
+   rules on failure.
+
+.. versionchanged:: 0.3.0
+   Added the ``float`` data type.
+
+.. _required:
+
+required
+--------
+If ``True`` the key/value pair is mandatory. Validation will fail when it is
+missing, unless :meth:`~cerberus.Validator.validate` is called with
+``update=True``:
+
+.. doctest::
+
+    >>> v.schema = {'name': {'required': True, 'type': 'string'}, 'age': {'type': 'integer'}}
+    >>> document = {'age': 10}
+    >>> v.validate(document)
+    False
+    >>> v.errors
+    {'name': 'required field'}
+
+    >>> v.validate(document, update=True)
+    True
+
+.. note::
+
+   String fields with empty values will still be validated, even when
+   ``required`` is set to ``True``. If you don't want to accept empty values,
+   see the empty_ rule. Also, if dependencies_ are declared for the field, its
+   ``required`` rule will only be validated if all dependencies are
+   included with the document.
+
+.. versionchanged:: 0.8
+   Check field dependencies.
+
+readonly
+--------
+If ``True`` the value is readonly. Validation will fail if this field is present
+in the target dictionary.
+
+nullable
+--------
+If ``True`` the field value can be set to ``None``. It is essentially the
+functionality of the :attr:`~cerberus.Validator.ignore_none_values` property
+of a :class:`~cerberus.Validator` instance, but allowing for more fine grained
+control down to the field level.
+
+.. doctest::
+
+    >>> v.schema = {'a_nullable_integer': {'nullable': True, 'type': 'integer'}, 'an_integer': {'type': 'integer'}}
+
+    >>> v.validate({'a_nullable_integer': 3})
+    True
+    >>> v.validate({'a_nullable_integer': None})
+    True
+
+    >>> v.validate({'an_integer': 3})
+    True
+    >>> v.validate({'an_integer': None})
+    False
+    >>> v.errors
+    {'an_integer': 'null value not allowed'}
+
+.. versionchanged:: 0.7 ``nullable`` is valid on fields lacking type definition.
+.. versionadded:: 0.3.0
+
+minlength, maxlength
+--------------------
+Minimum and maximum length allowed for ``string`` and ``list`` types.
+
+min, max
+--------
+Minimum and maximum value allowed for ``integer``, ``float`` and ``number``
+types.
+
+.. versionchanged:: 0.7
+   Added support for ``float`` and ``number`` types.
+
+allowed
+-------
+Allowed values for ``string``, ``list`` and ``int`` types. Validation will fail
+if target values are not included in the allowed list.
+
+.. doctest::
+
+    >>> v.schema = {'role': {'type': 'list', 'allowed': ['agent', 'client', 'supplier']}}
+    >>> v.validate({'role': ['agent', 'supplier']})
+    True
+
+    >>> v.validate({'role': ['intern']})
+    False
+    >>> v.errors
+    {'role': "unallowed values ['intern']"}
+
+    >>> v.schema = {'role': {'type': 'string', 'allowed': ['agent', 'client', 'supplier']}}
+    >>> v.validate({'role': 'supplier'})
+    True
+
+    >>> v.validate({'role': 'intern'})
+    False
+    >>> v.errors
+    {'role': 'unallowed value intern'}
+
+    >>> v.schema = {'a_restricted_integer': {'type': 'integer', 'allowed': [-1, 0, 1]}}
+    >>> v.validate({'a_restricted_integer': -1})
+    True
+
+    >>> v.validate({'a_restricted_integer': 2})
+    False
+    >>> v.errors
+    {'a_restricted_integer': 'unallowed value 2'}
+
+.. versionchanged:: 0.5.1
+   Added support for the ``int`` type.
+
+empty
+-----
+Only applies to string fields. If ``False`` validation will fail if the value
+is empty. Defaults to ``True``.
+
+.. doctest::
+
+    >>> schema = {'name': {'type': 'string', 'empty': False}}
+    >>> document = {'name': ''}
+    >>> v.validate(document, schema)
+    False
+
+    >>> v.errors
+    {'name': 'empty values not allowed'}
+
+.. versionadded:: 0.0.3
+
+items (dict)
+------------
+.. deprecated:: 0.0.3
+   Use `schema (dict)`_ instead.
+
+items (list)
+------------
+When a list, ``items`` defines a list of values allowed in a ``list`` type of
+fixed length in the given order:
+
+.. doctest::
+
+    >>> schema = {'list_of_values': {'type': 'list', 'items': [{'type': 'string'}, {'type': 'integer'}]}}
+    >>> document = {'list_of_values': ['hello', 100]}
+    >>> v.validate(document, schema)
+    True
+    >>> document = {'list_of_values': [100, 'hello']}
+    >>> v.validate(document, schema)
+    False
+
+See `schema (list)`_ rule below for dealing with arbitrary length ``list`` types.
+
+.. _schema_dict-rule:
+
+schema (dict)
+-------------
+If a field for which a ``schema``-rule is defined has a *mapping* as value,
+that mapping will be validated against the schema that is provided as
+constraint.
+
+.. doctest::
+
+    >>> schema = {'a_dict': {'type': 'dict', 'schema': {'address': {'type': 'string'},
+    ...                                                 'city': {'type': 'string', 'required': True}}}}
+    >>> document = {'a_dict': {'address': 'my address', 'city': 'my town'}}
+    >>> v.validate(document, schema)
+    True
+
+.. note::
+
+    To validate *arbitrary keys* of a mapping, see `propertyschema`_, resp.
+    `valueschema`_ for *arbitrary values* of a mapping.
+
+schema (list)
+-------------
+If ``schema``-validation encounters an arbritrary sized *sequence* as value,
+all items of the sequence will be validated against the rules provided in
+``schema``'s constraint.
+
+.. doctest::
+
+    >>> schema = {'a_list': {'type': 'list', 'schema': {'type': 'integer'}}}
+    >>> document = {'a_list': [3, 4, 5]}
+    >>> v.validate(document, schema)
+    True
+
+The `schema` rule on ``list`` types is also the preferred method for defining
+and validating a list of dictionaries.
+
+.. doctest::
+
+    >>> schema = {'rows': {'type': 'list',
+    ...                    'schema': {'type': 'dict', 'schema': {'sku': {'type': 'string'},
+    ...                                                          'price': {'type': 'integer'}}}}}
+    >>> document = {'rows': [{'sku': 'KT123', 'price': 100}]}
+    >>> v.validate(document, schema)
+    True
+
+.. versionchanged:: 0.0.3
+   Schema rule for ``list`` types of arbitrary length
+
+valueschema
+-----------
+Validation schema for all values of a ``dict``. The ``dict`` can have arbitrary
+keys, the values for all of which must validate with given schema:
+
+.. doctest::
+
+    >>> schema = {'numbers': {'type': 'dict', 'valueschema': {'type': 'integer', 'min': 10}}}
+    >>> document = {'numbers': {'an integer': 10, 'another integer': 100}}
+    >>> v.validate(document, schema)
+    True
+
+    >>> document = {'numbers': {'an integer': 9}}
+    >>> v.validate(document, schema)
+    False
+
+    >>> v.errors
+    {'numbers': {'an integer': 'min value is 10'}}
+
+.. versionadded:: 0.7
+.. versionchanged:: 0.9
+   renamed ``keyschema`` to ``valueschema``
+
+propertyschema
+--------------
+
+This is the counterpart to ``valueschema`` that validates the `keys` of a
+``dict``. For historical reasons it is `not` named ``keyschema``.
+
+.. doctest::
+
+    >>> schema = {'a_dict': {'type': 'dict', 'propertyschema': {'type': 'string', 'regex': '[a-z]+'}}}
+    >>> document = {'a_dict': {'key': 'value'}}
+    >>> v.validate(document, schema)
+    True
+
+    >>> document = {'a_dict': {'KEY': 'value'}}
+    >>> v.validate(document, schema)
+    False
+
+.. versionadded:: 0.9
+
+regex
+-----
+Validation will fail if field value does not match the provided regular
+expression. It is only tested on string values.
+
+.. doctest::
+
+    >>> schema = {'email': {'type': 'string', 'regex': '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$'}}
+    >>> document = {'email': 'john@example.com'}
+    >>> v.validate(document, schema)
+    True
+
+    >>> document = {'email': 'john_at_example_dot_com'}
+    >>> v.validate(document, schema)
+    False
+
+    >>> v.errors
+    {'email': "value does not match regex '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$'"}
+
+For details on regular expression syntax, see the documentation on the standard
+library's :mod:`re`-module.
+
+.. versionadded:: 0.7
+
+dependencies
+------------
+This rule allows for either a list or dict of dependencies. When a list is
+provided, all listed fields must be present in order for the target field to be
+validated.
+
+.. doctest::
+
+    >>> schema = {'field1': {'required': False}, 'field2': {'required': False, 'dependencies': ['field1']}}
+    >>> document = {'field1': 7}
+    >>> v.validate(document, schema)
+    True
+
+    >>> document = {'field2': 7}
+    >>> v.validate(document, schema)
+    False
+
+    >>> v.errors
+    {'field2': "field 'field1' is required"}
+
+When a dictionary is provided, then not only all dependencies must be present,
+but also any of their allowed values must be matched.
+
+.. doctest::
+
+    >>> schema = {'field1': {'required': False},
+    ...           'field2': {'required': True, 'dependencies': {'field1': ['one', 'two']}}}
+
+    >>> document = {'field1': 'one', 'field2': 7}
+    >>> v.validate(document, schema)
+    True
+
+    >>> document = {'field1': 'three', 'field2': 7}
+    >>> v.validate(document, schema)
+    False
+    >>> v.errors
+    {'field2': "field 'field1' is required with one of these values: ['one', 'two']"}
+
+    >>> # same as using a dependencies list
+    >>> document = {'field2': 7}
+    >>> v.validate(document, schema)
+    False
+    >>> v.errors
+    {'field2': "field 'field1' is required with one of these values: ['one', 'two']"}
+
+    >>> # one can also pass a single dependency value
+    >>> schema = {'field1': {'required': False}, 'field2': {'dependencies': {'field1': 'one'}}}
+    >>> document = {'field1': 'one', 'field2': 7}
+    >>> v.validate(document, schema)
+    True
+
+    >>> document = {'field1': 'two', 'field2': 7}
+    >>> v.validate(document, schema)
+    False
+
+    >>> v.errors
+    {'field2': "field 'field1' is required with one of these values: ['one']"}
+
+Dependencies on sub-document fields are also supported:
+
+.. doctest::
+
+    >>> schema = {
+    ...   'test_field': {'dependencies': ['a_dict.foo', 'a_dict.bar']},
+    ...   'a_dict': {
+    ...     'type': 'dict',
+    ...     'schema': {
+    ...       'foo': {'type': 'string'},
+    ...       'bar': {'type': 'string'}
+    ...     }
+    ...   }
+    ... }
+
+    >>> document = {'test_field': 'foobar', 'a_dict': {'foo': 'foo'}}
+    >>> v.validate(document, schema)
+    False
+
+    >>> v.errors
+    {'test_field': "field 'a_dict.bar' is required"}
+
+.. versionchanged:: 0.8.1 Support for sub-document fields as dependencies.
+
+.. versionchanged:: 0.8 Support for dependencies as a dictionary.
+
+.. versionadded:: 0.7
+
+\*of-rules
+----------
+
+These rules allow you to list multiple sets of rules to validate against. The
+field will be considered valid if it validates against the set in the list
+according to the prefixes logics ``all``, ``any``, ``one`` or ``none``.
+
+==========  ====================================================================
+``anyof``   Validates if *any* of the provided constraints validates the field.
+``allof``   Validates if *all* of the provided constraints validates the field.
+``noneof``  Validates if *none* of the provided constraints validates the field.
+``oneof``   Validates if *exactly one* of the provided constraints applies.
+==========  ====================================================================
+
+For example, to verify that a property is a number between 0 and 10 or 100 and
+110, you could do the following:
+
+.. doctest::
+
+    >>> schema = {'prop1':
+    ...           {'type': 'number',
+    ...            'anyof':
+    ...            [{'min': 0, 'max': 10}, {'min': 100, 'max': 110}]}}
+
+    >>> document = {'prop1': 5}
+    >>> v.validate(document, schema)
+    True
+
+    >>> document = {'prop1': 105}
+    >>> v.validate(document, schema)
+    True
+
+    >>> document = {'prop1': 55}
+    >>> v.validate(document, schema)
+    False
+    >>> v.errors   # doctest: +SKIP
+    {'prop1': {'anyof': 'no definitions validated', 'definition 1': 'min value is 100', 'definition 0': 'max value is 10'}}
+
+The ``anyof`` rule works by creating a new instance of a schema for each item
+in the list. The above schema is equivalent to creating two separate schemas:
+
+.. doctest::
+
+    >>> schema1 = {'prop1': {'type': 'number', 'min':   0, 'max':  10}}
+    >>> schema2 = {'prop1': {'type': 'number', 'min': 100, 'max': 110}}
+
+    >>> document = {'prop1': 5}
+    >>> v.validate(document, schema1) or v.validate(document, schema2)
+    True
+
+    >>> document = {'prop1': 105}
+    >>> v.validate(document, schema1) or v.validate(document, schema2)
+    True
+
+    >>> document = {'prop1': 55}
+    >>> v.validate(document, schema1) or v.validate(document, schema2)
+    False
+
+.. versionadded:: 0.9
+
+\*of-rules typesaver
+....................
+
+You can concatenate any of-rule with an underscore and another rule with a
+list of rule-values to save typing:
+
+.. testcode::
+
+    {'foo': {'anyof_type': ['string', 'integer']}}
+    # is equivalent to
+    {'foo': {'anyof': [{'type': 'string'}, {'type': 'integer'}]}}
+
+Thus you can use this to validate a document against several schemas without
+implementing your own logic:
+
+.. testsetup::
+
+    employees = ()
+
+.. doctest::
+
+    >>> schemas = [{'department': {'required': True, 'regex': '^IT$'}, 'phone': {'nullable': True}},
+    ...            {'department': {'required': True}, 'phone': {'required': True}}]
+    >>> emloyee_vldtr = Validator({'employee': {'oneof_schema': schemas, 'type': 'dict'}}, allow_unknown=True)
+    >>> invalid_employees_phones = []
+    >>> for employee in employees:
+    ...     if not employee_vldtr.validate(employee):
+    ...         invalid_employees_phones.append(employee)
+
+.. versionadded: 0.10
+
+
+excludes
+--------
+
+You can declare fields to excludes others:
+
+.. doctest::
+
+    >>> v = Validator()
+    >>> schema = {'this_field': {'type': 'dict',
+    ...                          'excludes': 'that_field'},
+    ...           'that_field': {'type': 'dict',
+    ...                          'excludes': 'this_field'}}
+    >>> v.validate({'this_field': {}, 'that_field': {}}, schema)
+    False
+    >>> v.validate({'this_field': {}}, schema)
+    True
+    >>> v.validate({'that_field': {}}, schema)
+    True
+    >>> v.validate({}, schema)
+    True
+
+
+You can require both field to build an exclusive `or`:
+
+.. doctest::
+
+    >>> v = Validator()
+    >>> schema = {'this_field': {'type': 'dict',
+    ...                          'excludes': 'that_field',
+    ...                          'required': True},
+    ...           'that_field': {'type': 'dict',
+    ...                          'excludes': 'this_field',
+    ...                          'required': True}}
+    >>> v.validate({'this_field': {}, 'that_field': {}}, schema)
+    False
+    >>> v.validate({'this_field': {}}, schema)
+    True
+    >>> v.validate({'that_field': {}}, schema)
+    True
+    >>> v.validate({}, schema)
+    False
+
+
+You can also pass multiples fields to exclude in a list :
+
+.. doctest::
+
+   >>> schema = {'this_field': {'type': 'dict',
+   ...                          'excludes': ['that_field', 'bazo_field']},
+   ...           'that_field': {'type': 'dict',
+   ...                          'excludes': 'this_field'},
+   ...           'bazo_field': {'type': 'dict'}}
+   >>> v.validate({'this_field': {}, 'bazo_field': {}}, schema)
+   False

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -1,6 +1,479 @@
 Validation Rules
 ================
 
+allowed
+-------
+Allowed values for ``string``, ``list`` and ``int`` types. Validation will fail
+if target values are not included in the allowed list.
+
+.. doctest::
+
+    >>> v.schema = {'role': {'type': 'list', 'allowed': ['agent', 'client', 'supplier']}}
+    >>> v.validate({'role': ['agent', 'supplier']})
+    True
+
+    >>> v.validate({'role': ['intern']})
+    False
+    >>> v.errors
+    {'role': "unallowed values ['intern']"}
+
+    >>> v.schema = {'role': {'type': 'string', 'allowed': ['agent', 'client', 'supplier']}}
+    >>> v.validate({'role': 'supplier'})
+    True
+
+    >>> v.validate({'role': 'intern'})
+    False
+    >>> v.errors
+    {'role': 'unallowed value intern'}
+
+    >>> v.schema = {'a_restricted_integer': {'type': 'integer', 'allowed': [-1, 0, 1]}}
+    >>> v.validate({'a_restricted_integer': -1})
+    True
+
+    >>> v.validate({'a_restricted_integer': 2})
+    False
+    >>> v.errors
+    {'a_restricted_integer': 'unallowed value 2'}
+
+.. versionchanged:: 0.5.1
+   Added support for the ``int`` type.
+
+dependencies
+------------
+This rule allows for either a list or dict of dependencies. When a list is
+provided, all listed fields must be present in order for the target field to be
+validated.
+
+.. doctest::
+
+   >>> schema = {'field1': {'required': False}, 'field2': {'required': False, 'dependencies': ['field1']}}
+   >>> document = {'field1': 7}
+   >>> v.validate(document, schema)
+   True
+
+   >>> document = {'field2': 7}
+   >>> v.validate(document, schema)
+   False
+
+   >>> v.errors
+   {'field2': "field 'field1' is required"}
+
+When a dictionary is provided, then not only all dependencies must be present,
+but also any of their allowed values must be matched.
+
+.. doctest::
+
+   >>> schema = {'field1': {'required': False},
+   ...           'field2': {'required': True, 'dependencies': {'field1': ['one', 'two']}}}
+
+   >>> document = {'field1': 'one', 'field2': 7}
+   >>> v.validate(document, schema)
+   True
+
+   >>> document = {'field1': 'three', 'field2': 7}
+   >>> v.validate(document, schema)
+   False
+   >>> v.errors
+   {'field2': "field 'field1' is required with one of these values: ['one', 'two']"}
+
+   >>> # same as using a dependencies list
+   >>> document = {'field2': 7}
+   >>> v.validate(document, schema)
+   False
+   >>> v.errors
+   {'field2': "field 'field1' is required with one of these values: ['one', 'two']"}
+
+   >>> # one can also pass a single dependency value
+   >>> schema = {'field1': {'required': False}, 'field2': {'dependencies': {'field1': 'one'}}}
+   >>> document = {'field1': 'one', 'field2': 7}
+   >>> v.validate(document, schema)
+   True
+
+   >>> document = {'field1': 'two', 'field2': 7}
+   >>> v.validate(document, schema)
+   False
+
+   >>> v.errors
+   {'field2': "field 'field1' is required with one of these values: ['one']"}
+
+Dependencies on sub-document fields are also supported:
+
+.. doctest::
+
+   >>> schema = {
+   ...   'test_field': {'dependencies': ['a_dict.foo', 'a_dict.bar']},
+   ...   'a_dict': {
+   ...     'type': 'dict',
+   ...     'schema': {
+   ...       'foo': {'type': 'string'},
+   ...       'bar': {'type': 'string'}
+   ...     }
+   ...   }
+   ... }
+
+   >>> document = {'test_field': 'foobar', 'a_dict': {'foo': 'foo'}}
+   >>> v.validate(document, schema)
+   False
+
+   >>> v.errors
+   {'test_field': "field 'a_dict.bar' is required"}
+
+.. versionchanged:: 0.8.1 Support for sub-document fields as dependencies.
+
+.. versionchanged:: 0.8 Support for dependencies as a dictionary.
+
+.. versionadded:: 0.7
+
+empty
+-----
+Only applies to string fields. If ``False`` validation will fail if the value
+is empty. Defaults to ``True``.
+
+.. doctest::
+
+    >>> schema = {'name': {'type': 'string', 'empty': False}}
+    >>> document = {'name': ''}
+    >>> v.validate(document, schema)
+    False
+
+    >>> v.errors
+    {'name': 'empty values not allowed'}
+
+.. versionadded:: 0.0.3
+
+excludes
+--------
+You can declare fields to excludes others:
+
+.. doctest::
+
+    >>> v = Validator()
+    >>> schema = {'this_field': {'type': 'dict',
+    ...                          'excludes': 'that_field'},
+    ...           'that_field': {'type': 'dict',
+    ...                          'excludes': 'this_field'}}
+    >>> v.validate({'this_field': {}, 'that_field': {}}, schema)
+    False
+    >>> v.validate({'this_field': {}}, schema)
+    True
+    >>> v.validate({'that_field': {}}, schema)
+    True
+    >>> v.validate({}, schema)
+    True
+
+
+You can require both field to build an exclusive `or`:
+
+.. doctest::
+
+    >>> v = Validator()
+    >>> schema = {'this_field': {'type': 'dict',
+    ...                          'excludes': 'that_field',
+    ...                          'required': True},
+    ...           'that_field': {'type': 'dict',
+    ...                          'excludes': 'this_field',
+    ...                          'required': True}}
+    >>> v.validate({'this_field': {}, 'that_field': {}}, schema)
+    False
+    >>> v.validate({'this_field': {}}, schema)
+    True
+    >>> v.validate({'that_field': {}}, schema)
+    True
+    >>> v.validate({}, schema)
+    False
+
+
+You can also pass multiples fields to exclude in a list :
+
+.. doctest::
+
+   >>> schema = {'this_field': {'type': 'dict',
+   ...                          'excludes': ['that_field', 'bazo_field']},
+   ...           'that_field': {'type': 'dict',
+   ...                          'excludes': 'this_field'},
+   ...           'bazo_field': {'type': 'dict'}}
+   >>> v.validate({'this_field': {}, 'bazo_field': {}}, schema)
+   False
+
+items (dict)
+------------
+.. deprecated:: 0.0.3
+   Use `schema (dict)`_ instead.
+
+items (list)
+------------
+When a list, ``items`` defines a list of values allowed in a ``list`` type of
+fixed length in the given order:
+
+.. doctest::
+
+   >>> schema = {'list_of_values': {'type': 'list', 'items': [{'type': 'string'}, {'type': 'integer'}]}}
+   >>> document = {'list_of_values': ['hello', 100]}
+   >>> v.validate(document, schema)
+   True
+   >>> document = {'list_of_values': [100, 'hello']}
+   >>> v.validate(document, schema)
+   False
+
+See `schema (list)`_ rule for dealing with arbitrary length ``list`` types.
+
+min, max
+--------
+Minimum and maximum value allowed for ``integer``, ``float`` and ``number``
+types.
+
+.. versionchanged:: 0.7
+  Added support for ``float`` and ``number`` types.
+
+minlength, maxlength
+--------------------
+Minimum and maximum length allowed for ``string`` and ``list`` types.
+
+nullable
+--------
+If ``True`` the field value can be set to ``None``. It is essentially the
+functionality of the :attr:`~cerberus.Validator.ignore_none_values` property
+of a :class:`~cerberus.Validator` instance, but allowing for more fine grained
+control down to the field level.
+
+.. doctest::
+
+   >>> v.schema = {'a_nullable_integer': {'nullable': True, 'type': 'integer'}, 'an_integer': {'type': 'integer'}}
+
+   >>> v.validate({'a_nullable_integer': 3})
+   True
+   >>> v.validate({'a_nullable_integer': None})
+   True
+
+   >>> v.validate({'an_integer': 3})
+   True
+   >>> v.validate({'an_integer': None})
+   False
+   >>> v.errors
+   {'an_integer': 'null value not allowed'}
+
+.. versionchanged:: 0.7 ``nullable`` is valid on fields lacking type definition.
+.. versionadded:: 0.3.0
+
+
+\*of-rules
+----------
+
+These rules allow you to list multiple sets of rules to validate against. The
+field will be considered valid if it validates against the set in the list
+according to the prefixes logics ``all``, ``any``, ``one`` or ``none``.
+
+==========  ====================================================================
+``anyof``   Validates if *any* of the provided constraints validates the field.
+``allof``   Validates if *all* of the provided constraints validates the field.
+``noneof``  Validates if *none* of the provided constraints validates the field.
+``oneof``   Validates if *exactly one* of the provided constraints applies.
+==========  ====================================================================
+
+For example, to verify that a property is a number between 0 and 10 or 100 and
+110, you could do the following:
+
+.. doctest::
+
+    >>> schema = {'prop1':
+    ...           {'type': 'number',
+    ...            'anyof':
+    ...            [{'min': 0, 'max': 10}, {'min': 100, 'max': 110}]}}
+
+    >>> document = {'prop1': 5}
+    >>> v.validate(document, schema)
+    True
+
+    >>> document = {'prop1': 105}
+    >>> v.validate(document, schema)
+    True
+
+    >>> document = {'prop1': 55}
+    >>> v.validate(document, schema)
+    False
+    >>> v.errors   # doctest: +SKIP
+    {'prop1': {'anyof': 'no definitions validated', 'definition 1': 'min value is 100', 'definition 0': 'max value is 10'}}
+
+The ``anyof`` rule works by creating a new instance of a schema for each item
+in the list. The above schema is equivalent to creating two separate schemas:
+
+.. doctest::
+
+    >>> schema1 = {'prop1': {'type': 'number', 'min':   0, 'max':  10}}
+    >>> schema2 = {'prop1': {'type': 'number', 'min': 100, 'max': 110}}
+
+    >>> document = {'prop1': 5}
+    >>> v.validate(document, schema1) or v.validate(document, schema2)
+    True
+
+    >>> document = {'prop1': 105}
+    >>> v.validate(document, schema1) or v.validate(document, schema2)
+    True
+
+    >>> document = {'prop1': 55}
+    >>> v.validate(document, schema1) or v.validate(document, schema2)
+    False
+
+.. versionadded:: 0.9
+
+\*of-rules typesaver
+....................
+
+You can concatenate any of-rule with an underscore and another rule with a
+list of rule-values to save typing:
+
+.. testcode::
+
+    {'foo': {'anyof_type': ['string', 'integer']}}
+    # is equivalent to
+    {'foo': {'anyof': [{'type': 'string'}, {'type': 'integer'}]}}
+
+Thus you can use this to validate a document against several schemas without
+implementing your own logic:
+
+.. testsetup::
+
+    employees = ()
+
+.. doctest::
+
+    >>> schemas = [{'department': {'required': True, 'regex': '^IT$'}, 'phone': {'nullable': True}},
+    ...            {'department': {'required': True}, 'phone': {'required': True}}]
+    >>> emloyee_vldtr = Validator({'employee': {'oneof_schema': schemas, 'type': 'dict'}}, allow_unknown=True)
+    >>> invalid_employees_phones = []
+    >>> for employee in employees:
+    ...     if not employee_vldtr.validate(employee):
+    ...         invalid_employees_phones.append(employee)
+
+.. versionadded: 0.10
+
+propertyschema
+--------------
+This is the counterpart to ``valueschema`` that validates the `keys` of a
+``dict``. For historical reasons it is `not` named ``keyschema``.
+
+.. doctest::
+
+    >>> schema = {'a_dict': {'type': 'dict', 'propertyschema': {'type': 'string', 'regex': '[a-z]+'}}}
+    >>> document = {'a_dict': {'key': 'value'}}
+    >>> v.validate(document, schema)
+    True
+
+    >>> document = {'a_dict': {'KEY': 'value'}}
+    >>> v.validate(document, schema)
+    False
+
+.. versionadded:: 0.9
+
+readonly
+--------
+If ``True`` the value is readonly. Validation will fail if this field is present
+in the target dictionary.
+
+regex
+-----
+Validation will fail if field value does not match the provided regular
+expression. It is only tested on string values.
+
+.. doctest::
+
+    >>> schema = {'email': {'type': 'string', 'regex': '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$'}}
+    >>> document = {'email': 'john@example.com'}
+    >>> v.validate(document, schema)
+    True
+
+    >>> document = {'email': 'john_at_example_dot_com'}
+    >>> v.validate(document, schema)
+    False
+
+    >>> v.errors
+    {'email': "value does not match regex '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$'"}
+
+For details on regular expression syntax, see the documentation on the standard
+library's :mod:`re`-module.
+
+.. versionadded:: 0.7
+
+.. _required:
+
+required
+--------
+If ``True`` the key/value pair is mandatory. Validation will fail when it is
+missing, unless :meth:`~cerberus.Validator.validate` is called with
+``update=True``:
+
+.. doctest::
+
+    >>> v.schema = {'name': {'required': True, 'type': 'string'}, 'age': {'type': 'integer'}}
+    >>> document = {'age': 10}
+    >>> v.validate(document)
+    False
+    >>> v.errors
+    {'name': 'required field'}
+
+    >>> v.validate(document, update=True)
+    True
+
+.. note::
+
+   String fields with empty values will still be validated, even when
+   ``required`` is set to ``True``. If you don't want to accept empty values,
+   see the empty_ rule. Also, if dependencies_ are declared for the field, its
+   ``required`` rule will only be validated if all dependencies are
+   included with the document.
+
+.. versionchanged:: 0.8
+   Check field dependencies.
+
+.. _schema_dict-rule:
+
+schema (dict)
+-------------
+If a field for which a ``schema``-rule is defined has a *mapping* as value,
+that mapping will be validated against the schema that is provided as
+constraint.
+
+.. doctest::
+
+    >>> schema = {'a_dict': {'type': 'dict', 'schema': {'address': {'type': 'string'},
+    ...                                                 'city': {'type': 'string', 'required': True}}}}
+    >>> document = {'a_dict': {'address': 'my address', 'city': 'my town'}}
+    >>> v.validate(document, schema)
+    True
+
+.. note::
+
+    To validate *arbitrary keys* of a mapping, see `propertyschema`_, resp.
+    `valueschema`_ for *arbitrary values* of a mapping.
+
+schema (list)
+-------------
+If ``schema``-validation encounters an arbritrary sized *sequence* as value,
+all items of the sequence will be validated against the rules provided in
+``schema``'s constraint.
+
+.. doctest::
+
+   >>> schema = {'a_list': {'type': 'list', 'schema': {'type': 'integer'}}}
+   >>> document = {'a_list': [3, 4, 5]}
+   >>> v.validate(document, schema)
+   True
+
+The `schema` rule on ``list`` types is also the preferred method for defining
+and validating a list of dictionaries.
+
+.. doctest::
+
+   >>> schema = {'rows': {'type': 'list',
+   ...                    'schema': {'type': 'dict', 'schema': {'sku': {'type': 'string'},
+   ...                                                          'price': {'type': 'integer'}}}}}
+   >>> document = {'rows': [{'sku': 'KT123', 'price': 100}]}
+   >>> v.validate(document, schema)
+   True
+
+.. versionchanged:: 0.0.3
+  Schema rule for ``list`` types of arbitrary length
+
 .. _type:
 
 type
@@ -97,205 +570,6 @@ A list of types can be used to allow different values:
 .. versionchanged:: 0.3.0
    Added the ``float`` data type.
 
-.. _required:
-
-required
---------
-If ``True`` the key/value pair is mandatory. Validation will fail when it is
-missing, unless :meth:`~cerberus.Validator.validate` is called with
-``update=True``:
-
-.. doctest::
-
-    >>> v.schema = {'name': {'required': True, 'type': 'string'}, 'age': {'type': 'integer'}}
-    >>> document = {'age': 10}
-    >>> v.validate(document)
-    False
-    >>> v.errors
-    {'name': 'required field'}
-
-    >>> v.validate(document, update=True)
-    True
-
-.. note::
-
-   String fields with empty values will still be validated, even when
-   ``required`` is set to ``True``. If you don't want to accept empty values,
-   see the empty_ rule. Also, if dependencies_ are declared for the field, its
-   ``required`` rule will only be validated if all dependencies are
-   included with the document.
-
-.. versionchanged:: 0.8
-   Check field dependencies.
-
-readonly
---------
-If ``True`` the value is readonly. Validation will fail if this field is present
-in the target dictionary.
-
-nullable
---------
-If ``True`` the field value can be set to ``None``. It is essentially the
-functionality of the :attr:`~cerberus.Validator.ignore_none_values` property
-of a :class:`~cerberus.Validator` instance, but allowing for more fine grained
-control down to the field level.
-
-.. doctest::
-
-    >>> v.schema = {'a_nullable_integer': {'nullable': True, 'type': 'integer'}, 'an_integer': {'type': 'integer'}}
-
-    >>> v.validate({'a_nullable_integer': 3})
-    True
-    >>> v.validate({'a_nullable_integer': None})
-    True
-
-    >>> v.validate({'an_integer': 3})
-    True
-    >>> v.validate({'an_integer': None})
-    False
-    >>> v.errors
-    {'an_integer': 'null value not allowed'}
-
-.. versionchanged:: 0.7 ``nullable`` is valid on fields lacking type definition.
-.. versionadded:: 0.3.0
-
-minlength, maxlength
---------------------
-Minimum and maximum length allowed for ``string`` and ``list`` types.
-
-min, max
---------
-Minimum and maximum value allowed for ``integer``, ``float`` and ``number``
-types.
-
-.. versionchanged:: 0.7
-   Added support for ``float`` and ``number`` types.
-
-allowed
--------
-Allowed values for ``string``, ``list`` and ``int`` types. Validation will fail
-if target values are not included in the allowed list.
-
-.. doctest::
-
-    >>> v.schema = {'role': {'type': 'list', 'allowed': ['agent', 'client', 'supplier']}}
-    >>> v.validate({'role': ['agent', 'supplier']})
-    True
-
-    >>> v.validate({'role': ['intern']})
-    False
-    >>> v.errors
-    {'role': "unallowed values ['intern']"}
-
-    >>> v.schema = {'role': {'type': 'string', 'allowed': ['agent', 'client', 'supplier']}}
-    >>> v.validate({'role': 'supplier'})
-    True
-
-    >>> v.validate({'role': 'intern'})
-    False
-    >>> v.errors
-    {'role': 'unallowed value intern'}
-
-    >>> v.schema = {'a_restricted_integer': {'type': 'integer', 'allowed': [-1, 0, 1]}}
-    >>> v.validate({'a_restricted_integer': -1})
-    True
-
-    >>> v.validate({'a_restricted_integer': 2})
-    False
-    >>> v.errors
-    {'a_restricted_integer': 'unallowed value 2'}
-
-.. versionchanged:: 0.5.1
-   Added support for the ``int`` type.
-
-empty
------
-Only applies to string fields. If ``False`` validation will fail if the value
-is empty. Defaults to ``True``.
-
-.. doctest::
-
-    >>> schema = {'name': {'type': 'string', 'empty': False}}
-    >>> document = {'name': ''}
-    >>> v.validate(document, schema)
-    False
-
-    >>> v.errors
-    {'name': 'empty values not allowed'}
-
-.. versionadded:: 0.0.3
-
-items (dict)
-------------
-.. deprecated:: 0.0.3
-   Use `schema (dict)`_ instead.
-
-items (list)
-------------
-When a list, ``items`` defines a list of values allowed in a ``list`` type of
-fixed length in the given order:
-
-.. doctest::
-
-    >>> schema = {'list_of_values': {'type': 'list', 'items': [{'type': 'string'}, {'type': 'integer'}]}}
-    >>> document = {'list_of_values': ['hello', 100]}
-    >>> v.validate(document, schema)
-    True
-    >>> document = {'list_of_values': [100, 'hello']}
-    >>> v.validate(document, schema)
-    False
-
-See `schema (list)`_ rule below for dealing with arbitrary length ``list`` types.
-
-.. _schema_dict-rule:
-
-schema (dict)
--------------
-If a field for which a ``schema``-rule is defined has a *mapping* as value,
-that mapping will be validated against the schema that is provided as
-constraint.
-
-.. doctest::
-
-    >>> schema = {'a_dict': {'type': 'dict', 'schema': {'address': {'type': 'string'},
-    ...                                                 'city': {'type': 'string', 'required': True}}}}
-    >>> document = {'a_dict': {'address': 'my address', 'city': 'my town'}}
-    >>> v.validate(document, schema)
-    True
-
-.. note::
-
-    To validate *arbitrary keys* of a mapping, see `propertyschema`_, resp.
-    `valueschema`_ for *arbitrary values* of a mapping.
-
-schema (list)
--------------
-If ``schema``-validation encounters an arbritrary sized *sequence* as value,
-all items of the sequence will be validated against the rules provided in
-``schema``'s constraint.
-
-.. doctest::
-
-    >>> schema = {'a_list': {'type': 'list', 'schema': {'type': 'integer'}}}
-    >>> document = {'a_list': [3, 4, 5]}
-    >>> v.validate(document, schema)
-    True
-
-The `schema` rule on ``list`` types is also the preferred method for defining
-and validating a list of dictionaries.
-
-.. doctest::
-
-    >>> schema = {'rows': {'type': 'list',
-    ...                    'schema': {'type': 'dict', 'schema': {'sku': {'type': 'string'},
-    ...                                                          'price': {'type': 'integer'}}}}}
-    >>> document = {'rows': [{'sku': 'KT123', 'price': 100}]}
-    >>> v.validate(document, schema)
-    True
-
-.. versionchanged:: 0.0.3
-   Schema rule for ``list`` types of arbitrary length
-
 valueschema
 -----------
 Validation schema for all values of a ``dict``. The ``dict`` can have arbitrary
@@ -318,279 +592,3 @@ keys, the values for all of which must validate with given schema:
 .. versionadded:: 0.7
 .. versionchanged:: 0.9
    renamed ``keyschema`` to ``valueschema``
-
-propertyschema
---------------
-
-This is the counterpart to ``valueschema`` that validates the `keys` of a
-``dict``. For historical reasons it is `not` named ``keyschema``.
-
-.. doctest::
-
-    >>> schema = {'a_dict': {'type': 'dict', 'propertyschema': {'type': 'string', 'regex': '[a-z]+'}}}
-    >>> document = {'a_dict': {'key': 'value'}}
-    >>> v.validate(document, schema)
-    True
-
-    >>> document = {'a_dict': {'KEY': 'value'}}
-    >>> v.validate(document, schema)
-    False
-
-.. versionadded:: 0.9
-
-regex
------
-Validation will fail if field value does not match the provided regular
-expression. It is only tested on string values.
-
-.. doctest::
-
-    >>> schema = {'email': {'type': 'string', 'regex': '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$'}}
-    >>> document = {'email': 'john@example.com'}
-    >>> v.validate(document, schema)
-    True
-
-    >>> document = {'email': 'john_at_example_dot_com'}
-    >>> v.validate(document, schema)
-    False
-
-    >>> v.errors
-    {'email': "value does not match regex '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$'"}
-
-For details on regular expression syntax, see the documentation on the standard
-library's :mod:`re`-module.
-
-.. versionadded:: 0.7
-
-dependencies
-------------
-This rule allows for either a list or dict of dependencies. When a list is
-provided, all listed fields must be present in order for the target field to be
-validated.
-
-.. doctest::
-
-    >>> schema = {'field1': {'required': False}, 'field2': {'required': False, 'dependencies': ['field1']}}
-    >>> document = {'field1': 7}
-    >>> v.validate(document, schema)
-    True
-
-    >>> document = {'field2': 7}
-    >>> v.validate(document, schema)
-    False
-
-    >>> v.errors
-    {'field2': "field 'field1' is required"}
-
-When a dictionary is provided, then not only all dependencies must be present,
-but also any of their allowed values must be matched.
-
-.. doctest::
-
-    >>> schema = {'field1': {'required': False},
-    ...           'field2': {'required': True, 'dependencies': {'field1': ['one', 'two']}}}
-
-    >>> document = {'field1': 'one', 'field2': 7}
-    >>> v.validate(document, schema)
-    True
-
-    >>> document = {'field1': 'three', 'field2': 7}
-    >>> v.validate(document, schema)
-    False
-    >>> v.errors
-    {'field2': "field 'field1' is required with one of these values: ['one', 'two']"}
-
-    >>> # same as using a dependencies list
-    >>> document = {'field2': 7}
-    >>> v.validate(document, schema)
-    False
-    >>> v.errors
-    {'field2': "field 'field1' is required with one of these values: ['one', 'two']"}
-
-    >>> # one can also pass a single dependency value
-    >>> schema = {'field1': {'required': False}, 'field2': {'dependencies': {'field1': 'one'}}}
-    >>> document = {'field1': 'one', 'field2': 7}
-    >>> v.validate(document, schema)
-    True
-
-    >>> document = {'field1': 'two', 'field2': 7}
-    >>> v.validate(document, schema)
-    False
-
-    >>> v.errors
-    {'field2': "field 'field1' is required with one of these values: ['one']"}
-
-Dependencies on sub-document fields are also supported:
-
-.. doctest::
-
-    >>> schema = {
-    ...   'test_field': {'dependencies': ['a_dict.foo', 'a_dict.bar']},
-    ...   'a_dict': {
-    ...     'type': 'dict',
-    ...     'schema': {
-    ...       'foo': {'type': 'string'},
-    ...       'bar': {'type': 'string'}
-    ...     }
-    ...   }
-    ... }
-
-    >>> document = {'test_field': 'foobar', 'a_dict': {'foo': 'foo'}}
-    >>> v.validate(document, schema)
-    False
-
-    >>> v.errors
-    {'test_field': "field 'a_dict.bar' is required"}
-
-.. versionchanged:: 0.8.1 Support for sub-document fields as dependencies.
-
-.. versionchanged:: 0.8 Support for dependencies as a dictionary.
-
-.. versionadded:: 0.7
-
-\*of-rules
-----------
-
-These rules allow you to list multiple sets of rules to validate against. The
-field will be considered valid if it validates against the set in the list
-according to the prefixes logics ``all``, ``any``, ``one`` or ``none``.
-
-==========  ====================================================================
-``anyof``   Validates if *any* of the provided constraints validates the field.
-``allof``   Validates if *all* of the provided constraints validates the field.
-``noneof``  Validates if *none* of the provided constraints validates the field.
-``oneof``   Validates if *exactly one* of the provided constraints applies.
-==========  ====================================================================
-
-For example, to verify that a property is a number between 0 and 10 or 100 and
-110, you could do the following:
-
-.. doctest::
-
-    >>> schema = {'prop1':
-    ...           {'type': 'number',
-    ...            'anyof':
-    ...            [{'min': 0, 'max': 10}, {'min': 100, 'max': 110}]}}
-
-    >>> document = {'prop1': 5}
-    >>> v.validate(document, schema)
-    True
-
-    >>> document = {'prop1': 105}
-    >>> v.validate(document, schema)
-    True
-
-    >>> document = {'prop1': 55}
-    >>> v.validate(document, schema)
-    False
-    >>> v.errors   # doctest: +SKIP
-    {'prop1': {'anyof': 'no definitions validated', 'definition 1': 'min value is 100', 'definition 0': 'max value is 10'}}
-
-The ``anyof`` rule works by creating a new instance of a schema for each item
-in the list. The above schema is equivalent to creating two separate schemas:
-
-.. doctest::
-
-    >>> schema1 = {'prop1': {'type': 'number', 'min':   0, 'max':  10}}
-    >>> schema2 = {'prop1': {'type': 'number', 'min': 100, 'max': 110}}
-
-    >>> document = {'prop1': 5}
-    >>> v.validate(document, schema1) or v.validate(document, schema2)
-    True
-
-    >>> document = {'prop1': 105}
-    >>> v.validate(document, schema1) or v.validate(document, schema2)
-    True
-
-    >>> document = {'prop1': 55}
-    >>> v.validate(document, schema1) or v.validate(document, schema2)
-    False
-
-.. versionadded:: 0.9
-
-\*of-rules typesaver
-....................
-
-You can concatenate any of-rule with an underscore and another rule with a
-list of rule-values to save typing:
-
-.. testcode::
-
-    {'foo': {'anyof_type': ['string', 'integer']}}
-    # is equivalent to
-    {'foo': {'anyof': [{'type': 'string'}, {'type': 'integer'}]}}
-
-Thus you can use this to validate a document against several schemas without
-implementing your own logic:
-
-.. testsetup::
-
-    employees = ()
-
-.. doctest::
-
-    >>> schemas = [{'department': {'required': True, 'regex': '^IT$'}, 'phone': {'nullable': True}},
-    ...            {'department': {'required': True}, 'phone': {'required': True}}]
-    >>> emloyee_vldtr = Validator({'employee': {'oneof_schema': schemas, 'type': 'dict'}}, allow_unknown=True)
-    >>> invalid_employees_phones = []
-    >>> for employee in employees:
-    ...     if not employee_vldtr.validate(employee):
-    ...         invalid_employees_phones.append(employee)
-
-.. versionadded: 0.10
-
-
-excludes
---------
-
-You can declare fields to excludes others:
-
-.. doctest::
-
-    >>> v = Validator()
-    >>> schema = {'this_field': {'type': 'dict',
-    ...                          'excludes': 'that_field'},
-    ...           'that_field': {'type': 'dict',
-    ...                          'excludes': 'this_field'}}
-    >>> v.validate({'this_field': {}, 'that_field': {}}, schema)
-    False
-    >>> v.validate({'this_field': {}}, schema)
-    True
-    >>> v.validate({'that_field': {}}, schema)
-    True
-    >>> v.validate({}, schema)
-    True
-
-
-You can require both field to build an exclusive `or`:
-
-.. doctest::
-
-    >>> v = Validator()
-    >>> schema = {'this_field': {'type': 'dict',
-    ...                          'excludes': 'that_field',
-    ...                          'required': True},
-    ...           'that_field': {'type': 'dict',
-    ...                          'excludes': 'this_field',
-    ...                          'required': True}}
-    >>> v.validate({'this_field': {}, 'that_field': {}}, schema)
-    False
-    >>> v.validate({'this_field': {}}, schema)
-    True
-    >>> v.validate({'that_field': {}}, schema)
-    True
-    >>> v.validate({}, schema)
-    False
-
-
-You can also pass multiples fields to exclude in a list :
-
-.. doctest::
-
-   >>> schema = {'this_field': {'type': 'dict',
-   ...                          'excludes': ['that_field', 'bazo_field']},
-   ...           'that_field': {'type': 'dict',
-   ...                          'excludes': 'this_field'},
-   ...           'bazo_field': {'type': 'dict'}}
-   >>> v.validate({'this_field': {}, 'bazo_field': {}}, schema)
-   False

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,4 @@
+# requirements to build documentation
+Sphinx
+sphinx_bootstrap_theme==0.4.7
+sphinxcontrib-issuetracker


### PR DESCRIPTION
this is a preview of a documentation rendered with bootstrap as theme.

imo, the code parts are better readable, the navigation is more straightforward and it suits small and large screens thanks to responsiveness.

for now *there still is an issue* with the external links in the navigation bar; the urls get an `.html` appended.

i'm not sure why i had https://ghbtns.com/ successfully integrated at one point, but then it broke for yet unknown reasons.

i would also be much in favor of sorting the rules alphabetically for a better lookup.