### PR TITLE
added minlength / maxlength to dictionaries

### DIFF
--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -696,12 +696,12 @@ class Validator(object):
                 self._error(field, errors.ERROR_MIN_VALUE.format(min_value))
 
     def _validate_maxlength(self, max_length, field, value):
-        if isinstance(value, Sequence):
+        if isinstance(value, (Sequence, Mapping)):
             if len(value) > max_length:
                 self._error(field, errors.ERROR_MAX_LENGTH.format(max_length))
 
     def _validate_minlength(self, min_length, field, value):
-        if isinstance(value, Sequence):
+        if isinstance(value, (Sequence, Mapping)):
             if len(value) < min_length:
                 self._error(field, errors.ERROR_MIN_LENGTH.format(min_length))
 

--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -696,12 +696,12 @@ class Validator(object):
                 self._error(field, errors.ERROR_MIN_VALUE.format(min_value))
 
     def _validate_maxlength(self, max_length, field, value):
-        if isinstance(value, (Sequence, Mapping)):
+        if isinstance(value, Iterable):
             if len(value) > max_length:
                 self._error(field, errors.ERROR_MAX_LENGTH.format(max_length))
 
     def _validate_minlength(self, min_length, field, value):
-        if isinstance(value, (Sequence, Mapping)):
+        if isinstance(value, Iterable):
             if len(value) < min_length:
                 self._error(field, errors.ERROR_MIN_LENGTH.format(min_length))
 

--- a/cerberus/tests/__init__.py
+++ b/cerberus/tests/__init__.py
@@ -113,6 +113,11 @@ class TestBase(unittest.TestCase):
                 'type': 'dict',
                 'propertyschema': {'type': 'string', 'regex': '[a-z]+'}
             },
+            'a_dict_with_restricted_length': {
+                'type': 'dict',
+                'minlength': 2,
+                'maxlength': 10
+            },
             'a_list_length': {
                 'type': 'list',
                 'schema': {'type': 'integer'},

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -1,7 +1,7 @@
 import re
 import sys
 from datetime import datetime
-from random import choice
+from random import choice, sample
 from string import ascii_lowercase
 from tempfile import NamedTemporaryFile
 from . import TestBase
@@ -184,6 +184,22 @@ class TestValidation(TestBase):
         field = 'a_string'
         min_length = self.schema[field]['minlength']
         value = "".join(choice(ascii_lowercase) for i in range(min_length - 1))
+        self.assertFail({field: value})
+        self.assertError(field, errors.ERROR_MIN_LENGTH.format(min_length))
+
+    def test_bad_max_length_dict(self):
+        field = 'a_dict_with_restricted_length'
+        max_length = self.schema[field]['maxlength']
+        keys = sample(ascii_lowercase, max_length + 1)
+        value = dict((key, choice(ascii_lowercase)) for key in keys)
+        self.assertFail({field: value})
+        self.assertError(field, errors.ERROR_MAX_LENGTH.format(max_length))
+
+    def test_bad_min_length_dict(self):
+        field = 'a_dict_with_restricted_length'
+        min_length = self.schema[field]['minlength']
+        keys = sample(ascii_lowercase, min_length - 1)
+        value = dict((key, choice(ascii_lowercase)) for key in keys)
         self.assertFail({field: value})
         self.assertError(field, errors.ERROR_MIN_LENGTH.format(min_length))
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -250,7 +250,7 @@ but allowing for more fine grained control down to the field level.
 
 minlength, maxlength
 ~~~~~~~~~~~~~~~~~~~~
-Minimum and maximum length allowed for ``string`` and ``list`` types.
+Minimum and maximum length allowed for ``string``, ``list`` and ``dict`` types.
 
 min, max
 ~~~~~~~~


### PR DESCRIPTION
The `minlength` / `maxlength` rule, formerly only usable with strings
and lists, is now compatible with arbitrary dictionaries.
Tests and custom field in scheme were added as well.

Updated docs accordingly.