### PR TITLE
Adds document- and schema-error trees to Validator

### DIFF
--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -18,7 +18,7 @@ import re
 
 from . import errors
 from .platform import _str_type, _int_types
-from .utils import warn_deprecated
+from .utils import drop_item_from_tuple, warn_deprecated
 
 
 log = logging.getLogger('cerberus')
@@ -186,6 +186,8 @@ class Validator(object):
 
         self.document = None
         self._errors = []
+        self.document_error_tree = errors.DocumentErrorTree()
+        self.schema_error_tree = errors.SchemaErrorTree()
         self.root_document = None
         self.root_schema = None
         self.document_path = ()
@@ -240,6 +242,10 @@ class Validator(object):
         """
         if len(args) == 1:
             self._errors.extend(args[0])
+            self._errors.sort()
+            for error in args[0]:
+                self.document_error_tree += error
+                self.schema_error_tree += error
         elif len(args) == 2 and isinstance(args[1], _str_type):
             self._error(args[0], errors.CUSTOM, args[1])
         elif len(args) >= 2:
@@ -251,7 +257,7 @@ class Validator(object):
             document_path = self.document_path + (field, )
 
             schema_path = self.schema_path
-            if code != errors.UNKNOWN_FIELD.code:
+            if code != errors.UNKNOWN_FIELD.code and rule is not None:
                 schema_path += (field, rule)
 
             if rule == 'nullable':
@@ -265,6 +271,9 @@ class Validator(object):
                                            code, rule, constraint,
                                            value, info)
             self._errors.append(error)
+            self._errors.sort()
+            self.document_error_tree += error
+            self.schema_error_tree += error
 
     def __get_child_validator(self, document_crumb=None, schema_crumb=None,
                               **kwargs):
@@ -296,6 +305,28 @@ class Validator(object):
             child_validator.schema_path = self.schema_path + schema_crumb
 
         return child_validator
+
+    def _drop_nodes_from_errorpaths(self, errors, dp_items, sp_items):
+        """ Removes nodes by index from an errorpath, relatively to the
+            basepaths of self.
+
+        :param errors: A list of :class:`errors.ValidationError` instances.
+        :param dp_items: A list of integers, pointing at the nodes to drop from
+                         the :attr:`document_path`.
+        :param sp_items: Alike ``dp_items``, but for :attr:`schema_path`.
+        """
+        dp_basedepth = len(self.document_path)
+        sp_basedepth = len(self.schema_path)
+        for error in errors:
+            for i in sorted(dp_items, reverse=True):
+                error.document_path = \
+                    drop_item_from_tuple(error.document_path, dp_basedepth+i)
+            for i in sorted(sp_items, reverse=True):
+                error.schema_path = \
+                    drop_item_from_tuple(error.schema_path, sp_basedepth+i)
+            if error.child_errors:
+                self._drop_nodes_from_errorpaths(error.child_errors,
+                                                 dp_items, sp_items)
 
     # Properties
 
@@ -436,7 +467,7 @@ class Validator(object):
                     'coerce' in self.allow_unknown:
                 coerce_value(self.allow_unknown['coerce'])
 
-    # TODO add document-/schema-crumbs if necessary
+    # TODO retrieve and store errors from child-validators
     def _normalize_containers(self, mapping, schema):
         for field in mapping:
             if isinstance(mapping[field], Mapping):
@@ -669,8 +700,8 @@ class Validator(object):
         elif isinstance(dependencies, Mapping):
             self.__validate_dependencies_mapping(dependencies, field)
 
-        # TODO test more precicely with error tree
-        if self.errors.get(field):
+        if self.document_error_tree.fetch_node_from(
+                self.schema_path + (field, 'dependencies')) is not None:
             return True
 
     def __validate_dependencies_mapping(self, dependencies, field):
@@ -773,14 +804,12 @@ class Validator(object):
             s.update(definition)
 
             validator = self.__get_child_validator(
-                schema_crumb=(field, operator, i),  # TODO skip-code?
+                schema_crumb=(field, operator, i),
                 schema={field: s})
             if validator({field: value}, normalize=False):
                 valid_counter += 1
             else:
-                for error in validator._errors:
-                    error.schema_path = \
-                        error.schema_path[:-2] + error.schema_path[-1:]
+                self._drop_nodes_from_errorpaths(validator._errors, [], [3])
                 _errors.extend(validator._errors)
 
         if operator == 'anyof' and valid_counter < 1:
@@ -839,11 +868,13 @@ class Validator(object):
     def _validate_propertyschema(self, schema, field, value):
         if isinstance(value, Mapping):
             validator = self.__get_child_validator(
+                document_crumb=(field,),
                 schema_crumb=(field, 'propertyschema'),
-                schema={field: {'schema': schema}})
-            if not validator({field: list(value.keys())}, normalize=False):
-                # TODO remove last 'schema' from error.schema_path
-                # TODO skip-code?
+                schema=dict(((k, schema) for k in value.keys())))
+            if not validator(dict(((k, k) for k in value.keys())),
+                             normalize=False):
+                self._drop_nodes_from_errorpaths(validator._errors,
+                                                 [], [2, 4])
                 self._error(field, errors.PROPERTYSCHEMA, validator._errors)
 
     def _validate_readonly(self, definition, field, value):
@@ -909,24 +940,14 @@ class Validator(object):
             self._error(validator._errors)
 
     def __validate_schema_sequence(self, field, schema, value):
-        schema_crumb = (field, 'schema')
-        sequence_errors = []
-        # TODO do not iterate
-        for i in range(len(value)):
-            validator = self.__get_child_validator(
-                document_crumb=field, schema_crumb=schema_crumb,  # TODO skip-code?  # noqa
-                schema={i: schema}, allow_unknown=self.allow_unknown)
-            validator({i: value[i]}, normalize=False)
-            sequence_errors.extend(validator._errors)
-        if sequence_errors:
-            for error in sequence_errors:
-                # get rid of the i that was made up before
-                # TODO generalize this
-                error.schema_path = \
-                    self.schema_path + schema_crumb + \
-                    error.schema_path[len(self.schema_path) +
-                                      len(schema_crumb)+1:]
-            self._error(field, errors.SEQUENCE_SCHEMA, sequence_errors)
+        schema = dict(((i, schema) for i in range(len(value))))
+        validator = self.__get_child_validator(
+            document_crumb=field, schema_crumb=(field, 'schema'),
+            schema=schema, allow_unknown=self.allow_unknown)
+        validator(dict(((i, v) for i, v in enumerate(value))), normalize=False)
+        if validator._errors:
+            self._drop_nodes_from_errorpaths(validator._errors, [], [2])
+            self._error(field, errors.SEQUENCE_SCHEMA, validator._errors)
 
     def _validate_type(self, definition, field, value):
         def call_type_validation(_type, value):
@@ -943,7 +964,7 @@ class Validator(object):
                 self._errors = prev_errors
                 return False
 
-        data_type = definition.get('type', None)
+        data_type = definition.get('type')
         if data_type is None:
             return
 
@@ -1003,16 +1024,11 @@ class Validator(object):
         schema_crumb = (field, 'valueschema')
         if isinstance(value, Mapping):
             validator = self.__get_child_validator(
-                    document_crumb=field, schema_crumb=schema_crumb,  # TODO skip-code?  # noqa
-                    schema=dict((k, schema) for k in value))
+                document_crumb=field, schema_crumb=schema_crumb,
+                schema=dict((k, schema) for k in value))
             validator(value, normalize=False)
             if validator._errors:
-                # get rid of k that was used before
-                # TODO generalize this
-                for error in validator._errors:
-                    error.schema_path = self.schema_path + schema_crumb + \
-                        error.schema_path[len(self.schema_path) +
-                                          len(schema_crumb)+1:]
+                self._drop_nodes_from_errorpaths(validator._errors, [], [2])
                 self._error(field, errors.VALUESCHEMA, validator._errors)
 
 

--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -855,6 +855,8 @@ class Validator(object):
     def _validate_regex(self, pattern, field, value):
         if not isinstance(value, _str_type):
             return
+        if not pattern.endswith('$'):
+            pattern += '$'
         re_obj = re.compile(pattern)
         if not re_obj.match(value):
             self._error(field, errors.REGEX_MISMATCH)

--- a/cerberus/errors.py
+++ b/cerberus/errors.py
@@ -2,7 +2,7 @@
 
 from collections import namedtuple
 from copy import copy
-from .utils import quote_string
+from .utils import compare_paths_lt, quote_string
 
 """
 Error definition constants
@@ -102,13 +102,28 @@ class ValidationError:
         self.value = value
         self.info = info
 
+    def __eq__(self, other):
+        """ Assumes the errors relate to the same document and schema. """
+        return hash(self) == hash(other)
+
+    def __hash__(self):
+        """ Expects that all other properties are transitively determined. """
+        return hash(self.document_path) ^ hash(self.schema_path) \
+            ^ hash(self.code)
+
+    def __lt__(self, other):
+        if self.document_path != other.document_path:
+            return compare_paths_lt(self.document_path, other.document_path)
+        else:
+            return compare_paths_lt(self.schema_path, other.schema_path)
+
     def __repr__(self):
         return "{class_name} @ {memptr} ( " \
                "document_path={document_path}," \
                "schema_path={schema_path}," \
                "code={code}," \
                "constraint={constraint}," \
-               "value={value}" \
+               "value={value}," \
                "info={info} )"\
                .format(class_name=self.__class__.__name__, memptr=hex(id(self)),  # noqa
                        document_path=self.document_path,

--- a/cerberus/errors.py
+++ b/cerberus/errors.py
@@ -1,6 +1,6 @@
 """ This module contains the error-related constants and classes. """
 
-from collections import namedtuple
+from collections import namedtuple, MutableMapping
 from copy import copy
 from .utils import compare_paths_lt, quote_string
 
@@ -89,9 +89,11 @@ SCHEMA_ERROR_UNKNOWN_RULE = "unknown rule '{0}' for field '{0}'"
 SCHEMA_ERROR_UNKNOWN_TYPE = "unrecognized data-type '{0}'"
 
 
+""" Error representations """
+
+
 class ValidationError:
     """ A simple class to store and query basic error information. """
-    # TODO implement __lt__ for sorting?
     def __init__(self, document_path, schema_path, code, rule, constraint,
                  value, info):
         self.document_path = document_path
@@ -138,10 +140,7 @@ class ValidationError:
         """
         A list that contain the individual errors of a bulk validation error.
         """
-        if self.is_group_error:
-            return self.info[0]
-        else:
-            return None
+        return self.info[0] if self.is_group_error else None
 
     @property
     def is_group_error(self):
@@ -152,6 +151,115 @@ class ValidationError:
     def is_logic_error(self):
         """ ``True`` for validation errors against different schemas. """
         return bool(self.code & LOGICAL.code - ERROR_GROUP.code)
+
+
+class ErrorTreeNode(MutableMapping):
+    def __init__(self, path, parent_node):
+        self.parent_node = parent_node
+        self.tree_root = self.parent_node.tree_root
+        self.tree_type = self.parent_node.tree_type
+        self.path = path[:len(self.parent_node.path)+1]
+        self.errors = []
+        self.descendants = dict()
+
+    def __add__(self, error):
+        self.add(error)
+        return self
+
+    def __delitem__(self, key):
+        del self.descendants[key]
+
+    def __iter__(self):
+        return iter(self.errors)
+
+    def __getitem__(self, item):
+        if item in self.descendants:
+            return self.descendants[item]
+        else:
+            return None
+
+    def __len__(self):
+        return len(self.descendants)
+
+    def __setitem__(self, key, value):
+        self.descendants[key] = value
+
+    def __str__(self):
+        return str(self.errors) + ',' + str(self.descendants)
+
+    def _path_of_(self, error):
+        return getattr(error, self.tree_type + '_path')
+
+    def add(self, error):
+        error_path = self._path_of_(error)
+
+        key = error_path[len(self.path)]
+        if key not in self.descendants:
+            self[key] = ErrorTreeNode(error_path, self)
+
+        if len(error_path) == self.depth + 1:
+            self[key].errors.append(error)
+            self[key].errors.sort()
+            if error.is_group_error:
+                for child_error in error.info[0]:
+                    self.tree_root += child_error
+        else:
+            self[key] += error
+
+    @property
+    def depth(self):
+        return len(self.path)
+
+
+class ErrorTree(ErrorTreeNode):
+    def __init__(self, errors=[]):
+        self.parent_node = None
+        self.tree_root = self
+        self.path = ()
+        self.errors = []
+        self.descendants = dict()
+        for error in errors:
+            self += error
+
+    def add(self, error):
+        if not self._path_of_(error):
+            self.errors.append(error)
+            self.errors.sort()
+        else:
+            super(ErrorTree, self).add(error)
+
+    def fetch_errors_from(self, path):
+        """ Returns all errors for a particular path.
+        :param path: Tuple of hashables.
+        """
+        node = self.fetch_node_from(path)
+        if node is not None:
+            return node.errors
+        else:
+            return []
+
+    def fetch_node_from(self, path):
+        """ Returns a node for a path or ``None``.
+        :param path:  Tuple of hashables.
+        """
+        context = self
+        for key in path:
+            context = context[key]
+            if context is None:
+                return None
+        return context
+
+
+class DocumentErrorTree(ErrorTree):
+    """ Implements a dict-like class to query errors by indexes following the
+        structure of a validated document. """
+    tree_type = 'document'
+
+
+class SchemaErrorTree(ErrorTree):
+    """ Implements a dict-like class to query errors by indexes following the
+        structure of the used schema. """
+    tree_type = 'schema'
 
 
 class BaseErrorHandler:
@@ -171,7 +279,6 @@ class BaseErrorHandler:
         raise NotImplementedError
 
 
-# FIXME rename to LegacyErrorHandler?
 class BasicErrorHandler(BaseErrorHandler):
     """ Models cerberus' legacy. Returns a dictionary. """
     messages = {0x00: "{0}",
@@ -261,11 +368,11 @@ class BasicErrorHandler(BaseErrorHandler):
                 self.tree[field] = node
         elif len(path) >= 1:
             if path[0] in self.tree:
-                new = BasicErrorHandler(tree=copy(self.tree[path[0]]))
+                new = self.__class__(tree=copy(self.tree[path[0]]))
                 new.insert_error(path[1:], node)
                 self.tree[path[0]].update(new.tree)
             else:
-                child_handler = BasicErrorHandler()
+                child_handler = self.__class__()
                 child_handler.insert_error(path[1:], node)
                 self.tree[path[0]] = child_handler.tree
 
@@ -294,7 +401,6 @@ class BasicErrorHandler(BaseErrorHandler):
                 self.insert_error(path, self.format_message(field, child_error))  # noqa
 
 
-# TODO add an ErrorTreeHandler (a dict with raw and verbose error-information)
 # TODO add a SerializeErrorHandler (xml, json, yaml)
 # TODO add a HumanErrorHandler supporting l10n
 # TODO add various error output showcases to the docs

--- a/cerberus/tests/__init__.py
+++ b/cerberus/tests/__init__.py
@@ -146,7 +146,7 @@ class TestBase(unittest.TestCase):
         except known_exception as e:
             self.assertTrue(msg == str(e)) if msg else self.assertTrue(True)
         except Exception as e:  # noqa
-            self.fail("%s not raised." % known_exception)
+            self.fail("'%s' raised, expected %s." % (e, known_exception))
 
     def assertFail(self, document, schema=None, validator=None, update=False):
         if validator is None:

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import re
-import sys
 from datetime import datetime
 from random import choice
 from string import ascii_lowercase
@@ -847,10 +846,7 @@ class TestValidation(TestBase):
         document = {'property': 'string'}
         self.assertEqual(v.validated(document), document)
         document = {'property': 0}
-        if sys.version_info[0] * 10 + sys.version_info[1] < 27:
-            self.assertEqual(v.validated(document), None)
-        else:
-            self.assertIsNone(v.validated(document))
+        self.assertIsNone(v.validated(document))
 
     def test_anyof(self):
         # prop1 must be either a number between 0 and 10

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -9,6 +9,9 @@ from . import TestBase
 from ..cerberus import errors, SchemaError, Validator
 
 
+ValidationError = errors.ValidationError
+
+
 class TestTestBase(TestBase):
     def _test_that_test_fails(self, test, *args):
         try:
@@ -396,6 +399,7 @@ class TestValidation(TestBase):
         self.assertError(field, (field, 'regex'), errors.REGEX_MISMATCH,
                          '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$')
 
+    # TODO remove on next major release
     def test_a_list_of_dicts_deprecated(self):
         self.assertSuccess(
             {
@@ -435,13 +439,22 @@ class TestValidation(TestBase):
 
     def test_a_dict_with_valueschema(self):
         self.assertSuccess(
-            {
-                'a_dict_with_valueschema': {
-                    'an integer': 99,
-                    'another integer': 100
-                }
-            }
-        )
+            {'a_dict_with_valueschema':
+                {'an integer': 99, 'another integer': 100}})
+
+        self.assertFail({'a_dict_with_valueschema': {'a string': '99'}})
+        self.assertChildErrors(
+            'a_dict_with_valueschema',
+            ('a_dict_with_valueschema', 'valueschema'),
+            errors.VALUESCHEMA, {'type': 'integer'}, child_errors=[
+                (('a_dict_with_valueschema', 'a string'),
+                 ('a_dict_with_valueschema', 'valueschema', 'type'),
+                 errors.BAD_TYPE, 'integer')])
+        self.assertIn('valueschema', self.validator.schema_error_tree
+                      ['a_dict_with_valueschema'])
+        self.assertEqual(len(self.validator.schema_error_tree
+                             ['a_dict_with_valueschema']['valueschema']
+                             .descendants), 1)
 
     def test_a_dict_with_propertyschema(self):
         self.assertSuccess(
@@ -507,8 +520,8 @@ class TestValidation(TestBase):
         self.assertError('test_field', ('test_field', 'type'), errors.BAD_TYPE,
                          'number', v_errors=v._errors)
         self.assertFail({'test_field': 0}, validator=v)
-        self.assertError('test_field', ('test_field', None,), errors.CUSTOM,
-                         None, ('Below the min',), v_errors=v._errors)
+        self.assertError('test_field', (), errors.CUSTOM, None,
+                         ('Below the min',), v_errors=v._errors)
         self.assertDictEqual(v.errors, {'test_field': 'Below the min'})
 
     def test_custom_validator(self):
@@ -521,8 +534,8 @@ class TestValidation(TestBase):
         v = MyValidator(schema)
         self.assertSuccess({'test_field': 7}, validator=v)
         self.assertFail({'test_field': 6}, validator=v)
-        self.assertError('test_field', ('test_field', None), errors.CUSTOM,
-                         None, ('Not an odd number',), v_errors=v._errors)
+        self.assertError('test_field', (), errors.CUSTOM, None,
+                         ('Not an odd number',), v_errors=v._errors)
         self.assertDictEqual(v.errors, {'test_field': 'Not an odd number'})
 
     def test_transparent_schema_rules(self):
@@ -835,7 +848,7 @@ class TestValidation(TestBase):
         v = Validator(schema)
 
         self.assertFail({'name': 'ItsMe', 'age': 2}, validator=v)
-        self.assertError('name', ('name', None), errors.CUSTOM, None,
+        self.assertError('name', (), errors.CUSTOM, None,
                          ('must be lowercase',), v_errors=v._errors)
         self.assertDictEqual(v.errors, {'name': 'must be lowercase'})
         self.assertSuccess({'name': 'itsme', 'age': 2}, validator=v)
@@ -1505,28 +1518,162 @@ class ErrorHandling(TestBase):
         self.assertTrue(error.is_group_error)
         self.assertTrue(error.is_logic_error)
 
+    def test_error_tree_1(self):
+        schema = {'foo': {'schema': {'bar': {'type': 'string'}}}}
+        document = {'foo': {'bar': 0}}
+        self.assertFail(document, schema)
+        d_error_tree = self.validator.document_error_tree
+        s_error_tree = self.validator.schema_error_tree
+        self.assertIn('foo', d_error_tree)
+        self.assertIn('bar', d_error_tree['foo'])
+        self.assertEqual(d_error_tree['foo']['bar'].errors[0].value, 0)
+        self.assertEqual(
+            d_error_tree.fetch_errors_from(('foo', 'bar'))[0].value, 0)
+        self.assertIn('foo', s_error_tree)
+        self.assertIn('schema', s_error_tree['foo'])
+        self.assertIn('bar', s_error_tree['foo']['schema'])
+        self.assertIn('type', s_error_tree['foo']['schema']['bar'])
+        self.assertEqual(
+            s_error_tree['foo']['schema']['bar']['type'].errors[0].value, 0)
+        self.assertEqual(
+            s_error_tree.fetch_errors_from(
+                ('foo', 'schema', 'bar', 'type'))[0].value, 0)
+
+    def test_error_tree_2(self):
+        schema = {'foo': {'anyof': [{'type': 'string'}, {'type': 'integer'}]}}
+        document = {'foo': []}
+        self.assertFail(document, schema)
+        d_error_tree = self.validator.document_error_tree
+        s_error_tree = self.validator.schema_error_tree
+        self.assertIn('foo', d_error_tree)
+        self.assertEqual(d_error_tree['foo'].errors[0].value, [])
+        self.assertIn('foo', s_error_tree)
+        self.assertIn('anyof', s_error_tree['foo'])
+        self.assertIn(0, s_error_tree['foo']['anyof'])
+        self.assertIn(1, s_error_tree['foo']['anyof'])
+        self.assertIn('type', s_error_tree['foo']['anyof'][0])
+        self.assertEqual(
+            s_error_tree['foo']['anyof'][0]['type'].errors[0].value, [])
+
+    def test_nested_error_paths(self):
+        # TODO regexps can be shortened when #169 is solved
+        schema = {'a_dict': {'propertyschema': {'type': 'integer'},
+                             'valueschema': {'regex': '[a-z]*$'}},
+                  'a_list': {'schema': {'type': 'string',
+                                        'oneof_regex': ['[a-z]*$', '[A-Z]*$']}}}
+        document = {'a_dict': {0: 'abc', 'one': 'abc', 2: 'aBc', 'three': 'abC'},  # noqa
+                    'a_list': [0, 'abc', 'abC']}
+        self.assertFail(document, schema)
+
+        _det = self.validator.document_error_tree
+        _set = self.validator.schema_error_tree
+
+        self.assertEqual(len(_det.errors), 0)
+        self.assertEqual(len(_set.errors), 0)
+
+        self.assertEqual(len(_det['a_dict'].errors), 2)
+        self.assertEqual(len(_set['a_dict'].errors), 0)
+
+        self.assertIsNone(_det['a_dict'][0])
+        self.assertEqual(len(_det['a_dict']['one'].errors), 1)
+        self.assertEqual(len(_det['a_dict'][2].errors), 1)
+        self.assertEqual(len(_det['a_dict']['three'].errors), 2)
+
+        self.assertEqual(len(_set['a_dict']['propertyschema'].errors), 1)
+        self.assertEqual(len(_set['a_dict']['valueschema'].errors), 1)
+
+        self.assertEqual(
+            len(_set['a_dict']['propertyschema']['type'].errors), 2)
+        self.assertEqual(len(_set['a_dict']['valueschema']['regex'].errors), 2)
+
+        _ref_err = ValidationError(
+            ('a_dict', 'one'), ('a_dict', 'propertyschema', 'type'),
+            errors.BAD_TYPE.code, 'type', 'integer', 'one', ())
+        self.assertEqual(_det['a_dict']['one'].errors[0], _ref_err)
+        self.assertEqual(_set['a_dict']['propertyschema']['type'].errors[0],
+                         _ref_err)
+
+        _ref_err = ValidationError(
+            ('a_dict', 2), ('a_dict', 'valueschema', 'regex'),
+            errors.REGEX_MISMATCH.code, 'regex', '[a-z]*$', 'aBc', ())
+        self.assertEqual(_det['a_dict'][2].errors[0], _ref_err)
+        self.assertEqual(
+            _set['a_dict']['valueschema']['regex'].errors[0], _ref_err)
+
+        _ref_err = ValidationError(
+            ('a_dict', 'three'), ('a_dict', 'propertyschema', 'type'),
+            errors.BAD_TYPE.code, 'type', 'integer', 'three', ())
+        self.assertEqual(_det['a_dict']['three'].errors[0], _ref_err)
+        self.assertEqual(
+            _set['a_dict']['propertyschema']['type'].errors[1], _ref_err)
+
+        _ref_err = ValidationError(
+            ('a_dict', 'three'), ('a_dict', 'valueschema', 'regex'),
+            errors.REGEX_MISMATCH.code, 'regex', '[a-z]*$', 'abC', ())
+        self.assertEqual(_det['a_dict']['three'].errors[1], _ref_err)
+        self.assertEqual(
+            _set['a_dict']['valueschema']['regex'].errors[1], _ref_err)
+
+        self.assertEqual(len(_det['a_list'].errors), 1)
+        self.assertEqual(len(_det['a_list'][0].errors), 1)
+        self.assertIsNone(_det['a_list'][1])
+        self.assertEqual(len(_det['a_list'][2].errors), 3)
+        self.assertEqual(len(_set['a_list'].errors), 0)
+        self.assertEqual(len(_set['a_list']['schema'].errors), 1)
+        self.assertEqual(len(_set['a_list']['schema']['type'].errors), 1)
+        self.assertEqual(
+            len(_set['a_list']['schema']['oneof'][0]['regex'].errors), 1)
+        self.assertEqual(
+            len(_set['a_list']['schema']['oneof'][1]['regex'].errors), 1)
+
+        _ref_err = ValidationError(
+            ('a_list', 0), ('a_list', 'schema', 'type'), errors.BAD_TYPE.code,
+            'type', 'string', 0, ())
+        self.assertEqual(_det['a_list'][0].errors[0], _ref_err)
+        self.assertEqual(_set['a_list']['schema']['type'].errors[0], _ref_err)
+
+        _ref_err = ValidationError(
+            ('a_list', 2), ('a_list', 'schema', 'oneof'), errors.ONEOF.code,
+            'oneof', 'irrelevant_at_this_point', 'abC', ())
+        self.assertEqual(_det['a_list'][2].errors[0], _ref_err)
+        self.assertEqual(_set['a_list']['schema']['oneof'].errors[0], _ref_err)
+
+        _ref_err = ValidationError(
+            ('a_list', 2), ('a_list', 'schema', 'oneof', 0, 'regex'),
+            errors.REGEX_MISMATCH.code, 'regex', '[a-z]*$', 'abC', ())
+        self.assertEqual(_det['a_list'][2].errors[1], _ref_err)
+        self.assertEqual(
+            _set['a_list']['schema']['oneof'][0]['regex'].errors[0], _ref_err)
+
+        _ref_err = ValidationError(
+            ('a_list', 2), ('a_list', 'schema', 'oneof', 1, 'regex'),
+            errors.REGEX_MISMATCH.code, 'regex', '[a-z]*$', 'abC', ())
+        self.assertEqual(_det['a_list'][2].errors[2], _ref_err)
+        self.assertEqual(
+            _set['a_list']['schema']['oneof'][1]['regex'].errors[0], _ref_err)
+
     def test_basic_error_handler(self):
         handler = errors.BasicErrorHandler()
         _errors, ref = [], {}
 
-        _errors.append(errors.ValidationError(
+        _errors.append(ValidationError(
             ['foo'], ['foo'], 0x62, 'readonly', True, None, ()))
         ref.update({'foo': handler.messages[0x62]})
         self.assertDictEqual(handler(_errors), ref)
 
-        _errors.append(errors.ValidationError(
+        _errors.append(ValidationError(
             ['bar'], ['foo'], 0x42, 'min', 1, 2, ()))
         ref.update({'bar': handler.messages[0x42].format(constraint=1)})
         self.assertDictEqual(handler(_errors), ref)
 
-        _errors.append(errors.ValidationError(
+        _errors.append(ValidationError(
             ['zap', 'foo'], ['zap', 'schema', 'foo'], 0x24, 'type', 'string',
             True, ()))
         ref.update({'zap': {'foo': handler.messages[0x24].format(
             constraint='string')}})
         self.assertDictEqual(handler(_errors), ref)
 
-        _errors.append(errors.ValidationError(
+        _errors.append(ValidationError(
             ['zap', 'foo'], ['zap', 'schema', 'foo'], 0x41, 'regex',
             '^p[äe]ng$', 'boom', ()))
         ref['zap']['foo'] = \

--- a/cerberus/utils.py
+++ b/cerberus/utils.py
@@ -1,8 +1,25 @@
 import logging
 
-from .platform import _str_type
+from .platform import _int_types, _str_type
 
 log = logging.getLogger('cerberus')
+depr_warnings_printed = {}
+
+
+def compare_paths_lt(x, y):
+    for i in range(min(len(x), len(y))):
+        if isinstance(x[i], type(y[i])):
+            if x[i] != y[i]:
+                return x[i] < y[i]
+        elif isinstance(x[i], _int_types):
+            return True
+        elif isinstance(y[i], _int_types):
+            return False
+    return len(x) < len(y)
+
+
+def drop_item_from_tuple(t, i):
+    return t[:i] + t[i+1:]
 
 
 def quote_string(value):
@@ -10,9 +27,6 @@ def quote_string(value):
         return '"%s"' % value
     else:
         return value
-
-
-depr_warnings_printed = {}
 
 
 def warn_deprecated(artifact, message):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,11 +17,15 @@ ErrorHandlers
 
 .. autoclass:: cerberus.errors.BasicErrorHandler
 
-Python Error Representation
----------------------------
+Python Error Representations
+----------------------------
 
 .. autoclass:: cerberus.errors.ValidationError
   :members:
+
+.. autoclass:: cerberus.errors.DocumentErrorTree
+
+.. autoclass:: cerberus.errors.SchemaErrorTree
 
 Exceptions
 ----------

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -54,5 +54,36 @@ instance after a processing of a document:
   - ``_errors``: This list holds all submitted errors. It is not intended to
     manipulate errors directly via this attribute.
 
+  - ``document_error_tree``: A ``dict``-like object that allows you to query
+    nodes corresponding to your document. That node's errors are contained in
+    its :attr:`errors` property and are yielded when iterating over a node.
+    If no errors occurred in a node or below, ``None`` will be returned
+    instead.
+
+  - ``schema_error_tree``: Similarly for the used schema.
+
 .. versionchanged:: 0.10
     Errors are stored as :class:`~cerberus.errors.ValidationError` in a list.
+
+Examples
+~~~~~~~~
+
+.. doctest::
+
+    >>> schema = {'cats': {'type': 'integer'}}
+    >>> document = {'cats': 'two'}
+    >>> v.validate(document, schema)
+    False
+    >>> v.document_error_tree['cats'].errors == v.schema_error_tree['cats']['type'].errors
+    True
+    >>> error = v.document_error_tree['cats'].errors[0]
+    >>> error.document_path
+    ('cats',)
+    >>> error.schema_path
+    ('cats', 'type')
+    >>> error.rule
+    'type'
+    >>> error.constraint
+    'integer'
+    >>> error.value
+    'two'


### PR DESCRIPTION
This allows error-querying nodes through a container-interface.
And some smaller cleanup.

docs are still missing