### PR TITLE
Refactors `__validate_definitions` to a more generalised manner

### DIFF
--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -1179,9 +1179,8 @@ class TestValidation(TestBase):
         self.assertTrue(v.validate(document))
 
     def test_dont_type_validate_nulled_values(self):
-        v = self.validator
-        v.validate({'an_integer': None})
-        self.assertDictEqual(v.errors,
+        self.assertFail({'an_integer': None})
+        self.assertDictEqual(self.validator.errors,
                              {'an_integer': 'null value not allowed'})
 
     def test_dependencies_error(self):

--- a/docs/customize.rst
+++ b/docs/customize.rst
@@ -246,3 +246,17 @@ schema that was traversed by possible parent-validators. Both will be used as
 base path when an error is submitted.
 
 .. versionadded:: 0.10
+
+`Validator.mandatory_validations` & `Validator.priority_validations`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can override these class properties if you want to adjust the validation
+logic for each field validation.
+``mandatory_validations`` is a tuple that contains rules that will be validated
+for each field, regardless if the rule is defined for a field in a schema or
+not.
+``priority_validations`` is a tuple of ordered rules that will be validated
+before any other. If the validation method or function returns ``True``, no
+further rule will be considered for that field.
+
+.. versionadded:: 0.10


### PR DESCRIPTION
- skips unnecessary method calls
- adds `normalization_rules`-property to `Validator`

that bugged me since the last refactoring. eventually i did it.