### PR TITLE
Add default normalization rule

### DIFF
--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -454,6 +454,7 @@ class Validator(object):
         if self.purge_unknown:
             self._normalize_purge_unknown(mapping, schema)
         self._normalize_coerce(mapping, schema)
+        self._normalize_default(mapping, schema)
         self.__normalize_containers(mapping, schema)
         return mapping
 
@@ -563,6 +564,11 @@ class Validator(object):
             new_name = schema[field]['rename_handler'](field)
             mapping[new_name] = mapping[field]
             del mapping[field]
+
+    def _normalize_default(self, mapping, schema):
+        for field in tuple(schema):
+            if 'default' in schema[field] and field not in mapping:
+                mapping[field] = schema[field]['default']
 
     # # Validating
 

--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -567,7 +567,10 @@ class Validator(object):
 
     def _normalize_default(self, mapping, schema):
         for field in tuple(schema):
-            if 'default' in schema[field] and field not in mapping:
+            nullable = schema[field].get('nullable', False)
+            if 'default' in schema[field] and \
+                    (field not in mapping or
+                     mapping[field] is None and not nullable):
                 mapping[field] = schema[field]['default']
 
     # # Validating

--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -453,8 +453,8 @@ class Validator(object):
         self.__normalize_rename_fields(mapping, schema)
         if self.purge_unknown:
             self._normalize_purge_unknown(mapping, schema)
-        self._normalize_coerce(mapping, schema)
         self._normalize_default(mapping, schema)
+        self._normalize_coerce(mapping, schema)
         self.__normalize_containers(mapping, schema)
         return mapping
 

--- a/cerberus/tests/__init__.py
+++ b/cerberus/tests/__init__.py
@@ -235,3 +235,11 @@ class TestBase(unittest.TestCase):
     def assertBadType(self, field, data_type, value):
         self.assertFail({field: value})
         self.assertError(field, (field, 'type'), errors.BAD_TYPE, data_type)
+
+    def assertNormalizedEqual(self, document, expected, schema=None,
+                              validator=None):
+        if validator is None:
+            validator = self.validator
+
+        self.assertSuccess(document, schema, validator)
+        self.assertDictEqual(validator.document, expected)

--- a/cerberus/tests/__init__.py
+++ b/cerberus/tests/__init__.py
@@ -236,8 +236,7 @@ class TestBase(unittest.TestCase):
         self.assertFail({field: value})
         self.assertError(field, (field, 'type'), errors.BAD_TYPE, data_type)
 
-    def assertNormalizedEqual(self, document, expected, schema=None,
-                              validator=None):
+    def assertNormalized(self, document, expected, schema=None, validator=None):
         if validator is None:
             validator = self.validator
 

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -1322,14 +1322,14 @@ class TestNormalization(TestBase):
         schema = {'amount': {'coerce': int}}
         document = {'amount': '1'}
         expected = {'amount': 1}
-        self.assertNormalizedEqual(document, expected, schema)
+        self.assertNormalized(document, expected, schema)
 
     def test_coerce_in_subschema(self):
         schema = {'thing': {'type': 'dict',
                             'schema': {'amount': {'coerce': int}}}}
         document = {'thing': {'amount': '2'}}
         expected = {'thing': {'amount': 2}}
-        self.assertNormalizedEqual(document, expected, schema)
+        self.assertNormalized(document, expected, schema)
 
     def test_coerce_not_destructive(self):
         schema = {
@@ -1361,19 +1361,19 @@ class TestNormalization(TestBase):
         schema = {'foo': {'schema': {}, 'allow_unknown': {'coerce': int}}}
         document = {'foo': {'bar': '0'}}
         expected = {'foo': {'bar': 0}}
-        self.assertNormalizedEqual(document, expected, schema)
+        self.assertNormalized(document, expected, schema)
 
     def test_normalized(self):
         schema = {'amount': {'coerce': int}}
         document = {'amount': '2'}
         expected = {'amount': 2}
-        self.assertNormalizedEqual(document, expected, schema)
+        self.assertNormalized(document, expected, schema)
 
     def test_rename(self):
         schema = {'foo': {'rename': 'bar'}}
         document = {'foo': 0}
         expected = {'bar': 0}
-        # We cannot use assertNormalizedEqual here since there is bug where
+        # We cannot use assertNormalized here since there is bug where
         # Cerberus says that the renamed field is an unknown field:
         # {'bar': 'unknown field'}
         self.validator(document, schema, False)
@@ -1384,14 +1384,14 @@ class TestNormalization(TestBase):
         schema = {}
         document = {'0': 'foo'}
         expected = {0: 'foo'}
-        self.assertNormalizedEqual(document, expected, schema, validator)
+        self.assertNormalized(document, expected, schema, validator)
 
     def test_purge_unknown(self):
         validator = Validator(purge_unknown=True)
         schema = {'foo': {'type': 'string'}}
         document = {'bar': 'foo'}
         expected = {}
-        self.assertNormalizedEqual(document, expected, schema, validator)
+        self.assertNormalized(document, expected, schema, validator)
 
     def test_purge_unknown_in_subschema(self):
         schema = {'foo': {'type': 'dict',
@@ -1399,7 +1399,7 @@ class TestNormalization(TestBase):
                           'purge_unknown': True}}
         document = {'foo': {'bar': ''}}
         expected = {'foo': {}}
-        self.assertNormalizedEqual(document, expected, schema)
+        self.assertNormalized(document, expected, schema)
 
     def test_issue_147_complex(self):
         schema = {'revision': {'coerce': int}}
@@ -1430,7 +1430,7 @@ class TestNormalization(TestBase):
                                             'type': 'integer'}}}
         document = {'thing': {'amount': '2'}}
         expected = {'thing': {'amount': 2}}
-        self.assertNormalizedEqual(document, expected, schema)
+        self.assertNormalized(document, expected, schema)
 
     def test_coerce_in_propertyschema(self):
         # https://github.com/nicolaiarocci/cerberus/issues/155
@@ -1439,7 +1439,7 @@ class TestNormalization(TestBase):
                                                'type': 'integer'}}}
         document = {'thing': {'5': 'foo'}}
         expected = {'thing': {5: 'foo'}}
-        self.assertNormalizedEqual(document, expected, schema)
+        self.assertNormalized(document, expected, schema)
 
     def test_coercion_of_sequence_items(self):
         # https://github.com/nicolaiarocci/cerberus/issues/161
@@ -1447,7 +1447,7 @@ class TestNormalization(TestBase):
                                                         'coerce': float}}}
         document = {'a_list': [3, 4, 5]}
         expected = {'a_list': [3.0, 4.0, 5.0]}
-        self.assertNormalizedEqual(document, expected, schema)
+        self.assertNormalized(document, expected, schema)
         for x in self.validator.document['a_list']:
             self.assertIsInstance(x, float)
 
@@ -1457,14 +1457,14 @@ class TestNormalization(TestBase):
                           'default': 'bar_value'}}
         document = {'foo': 'foo_value'}
         expected = {'foo': 'foo_value', 'bar': 'bar_value'}
-        self.assertNormalizedEqual(document, expected, schema)
+        self.assertNormalized(document, expected, schema)
 
     def test_default_existent(self):
         schema = {'foo': {'type': 'string'},
                   'bar': {'type': 'string',
                           'default': 'bar_value'}}
         document = {'foo': 'foo_value', 'bar': 'non_default'}
-        self.assertNormalizedEqual(document, document.copy(), schema)
+        self.assertNormalized(document, document.copy(), schema)
 
     def test_default_none(self):
         schema = {'foo': {'type': 'string'},
@@ -1472,7 +1472,7 @@ class TestNormalization(TestBase):
                           'nullable': True,
                           'default': 'bar_value'}}
         document = {'foo': 'foo_value', 'bar': None}
-        self.assertNormalizedEqual(document, document.copy(), schema)
+        self.assertNormalized(document, document.copy(), schema)
 
     def test_default_missing_in_subschema(self):
         schema = {'thing': {'type': 'dict',
@@ -1482,7 +1482,7 @@ class TestNormalization(TestBase):
         document = {'thing': {'foo': 'foo_value'}}
         expected = {'thing': {'foo': 'foo_value',
                               'bar': 'bar_value'}}
-        self.assertNormalizedEqual(document, expected, schema)
+        self.assertNormalized(document, expected, schema)
 
 
 class DefinitionSchema(TestBase):

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -1466,12 +1466,20 @@ class TestNormalization(TestBase):
         document = {'foo': 'foo_value', 'bar': 'non_default'}
         self.assertNormalized(document, document.copy(), schema)
 
-    def test_default_none(self):
+    def test_default_none_nullable(self):
         schema = {'foo': {'type': 'string'},
                   'bar': {'type': 'string',
                           'nullable': True,
                           'default': 'bar_value'}}
         document = {'foo': 'foo_value', 'bar': None}
+        self.assertNormalized(document, document.copy(), schema)
+
+    def test_default_none_nonnullable(self):
+        schema = {'foo': {'type': 'string'},
+                  'bar': {'type': 'string',
+                          'nullable': False,
+                          'default': 'bar_value'}}
+        document = {'foo': 'foo_value', 'bar': 'bar_value'}
         self.assertNormalized(document, document.copy(), schema)
 
     def test_default_missing_in_subschema(self):

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -1438,6 +1438,45 @@ class TestNormalization(TestBase):
         for x in result['a_list']:
             self.assertIsInstance(x, float)
 
+    def test_default_missing(self):
+        schema = {'foo': {'type': 'string'},
+                  'bar': {'type': 'string',
+                          'default': 'bar_value'}}
+
+        self.assertSuccess({'foo': 'foo_value'}, schema)
+        result = self.validator.document
+        self.assertDictEqual(result, {'foo': 'foo_value', 'bar': 'bar_value'})
+
+    def test_default_existent(self):
+        schema = {'foo': {'type': 'string'},
+                  'bar': {'type': 'string',
+                          'default': 'bar_value'}}
+
+        self.assertSuccess({'foo': 'foo_value', 'bar': 'non_default'}, schema)
+        result = self.validator.document
+        self.assertDictEqual(result, {'foo': 'foo_value', 'bar': 'non_default'})
+
+    def test_default_none(self):
+        schema = {'foo': {'type': 'string'},
+                  'bar': {'type': 'string',
+                          'nullable': True,
+                          'default': 'bar_value'}}
+
+        self.assertSuccess({'foo': 'foo_value', 'bar': None}, schema)
+        result = self.validator.document
+        self.assertDictEqual(result, {'foo': 'foo_value', 'bar': None})
+
+    def test_default_missing_in_subschema(self):
+        schema = {'thing': {'type': 'dict',
+                            'schema': {'foo': {'type': 'string'},
+                                       'bar': {'type': 'string',
+                                               'default': 'bar_value'}}}}
+
+        self.assertSuccess({'thing': {'foo': 'foo_value'}}, schema)
+        result = self.validator.document
+        self.assertDictEqual(result, {'thing': {'foo': 'foo_value',
+                                                'bar': 'bar_value'}})
+
 
 class DefinitionSchema(TestBase):
     def test_validated_schema_cache(self):

--- a/docs/normalization-rules.rst
+++ b/docs/normalization-rules.rst
@@ -39,6 +39,24 @@ subdocuments like ``allow_unknown`` (see :ref:`allowing-the-unknown`). The defau
 
 .. versionadded:: 0.10
 
+Default Values
+--------------
+You can set default values for missing fields in the document by using the ``default`` rule.
+
+.. doctest::
+
+   >>> v.schema = {'amount': {'type': 'integer'}, 'kind': {'type': 'string', 'default': 'purchase'}}
+   >>> v.normalized({'amount': 1})
+   {'amount': 1, 'kind': 'purchase'}
+
+   >>> v.normalized({'amount': 1, 'kind': 'other'})
+   {'amount': 1, 'kind': 'other'}
+
+   >>> v.normalized({'amount': 1, 'kind': None})
+   {'amount': 1, 'kind': None}
+
+.. versionadded:: 0.10
+
 .. _type-coercion:
 
 Value Coercion


### PR DESCRIPTION
This is for #131, it adds the `default` normalization rule to add missing fields in the document. Few examples:

```python
>>> schema = {'amount': {'type': 'integer'}, 'kind': {'type': 'string', 'default': 'purchase'}}
>>> v.validated({'amount': 1}, schema)
{'amount': 1, 'kind': 'purchase'}
>>> v.validated({'amount': 1, 'kind': 'other'}, schema)
{'amount': 1, 'kind': 'other'}
>>> v.validated({'amount': 1, 'kind': None}, schema)
{'amount': 1, 'kind': None}
>>> schema = {'thing': {'type': 'dict', 'schema': {'kind': {'type': 'string', 'default': 'purchase'}}
>>> v.validated({'thing': {}}, schema)
{'thing': {'kind': 'purchase'}}
```

### Concerns and thoughts

* If `nullable` is `False`, value is `None` and `default` is present, should we override the field with `default` or throw a validation error?
* If `default` is a callable, should we run the callable and set the callable result? Do we need another option like `default_is_callable` that when is `True` we call the `default` value if is a callable and when is `False` we don't call anything? We also can always call the `default` value if is callable and if the user really want to set a function definition as a default value for the document, she could wrap it with a lambda function or something like that.