### PR TITLE
Allow None in default normalization rule

### DIFF
--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -673,6 +673,7 @@ class Validator(object):
             del mapping[field]
 
     def _normalize_default(self, mapping, schema):
+        """ {'nullable': True} """
         for field in tuple(schema):
             nullable = schema[field].get('nullable', False)
             if 'default' in schema[field] and \

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -1474,6 +1474,15 @@ class TestNormalization(TestBase):
         document = {'foo': 'foo_value', 'bar': 'bar_value'}
         self.assertNormalized(document, document.copy(), schema)
 
+    def test_default_none_default_value(self):
+        schema = {'foo': {'type': 'string'},
+                  'bar': {'type': 'string',
+                          'nullable': True,
+                          'default': None}}
+        document = {'foo': 'foo_value'}
+        expected = {'foo': 'foo_value', 'bar': None}
+        self.assertNormalized(document, expected, schema)
+
     def test_default_missing_in_subschema(self):
         schema = {'thing': {'type': 'dict',
                             'schema': {'foo': {'type': 'string'},


### PR DESCRIPTION
Right now, if I try to use this schema:

```
{
    'bar': {
        'type': 'string',
        'nullable': True,
        'default': None
    }
}
```

I get the following exception:

```
cerberus.schema.SchemaError: {'bar': {'default': 'null value not allowed'}}
```

This PR allows us to have `None` as default value.