### PR TITLE
Allow callables for 'default' in schema (and minor fixes)

### DIFF
--- a/cerberus/errors.py
+++ b/cerberus/errors.py
@@ -52,6 +52,7 @@ FORBIDDEN_VALUES = ErrorDefinition(0x47, 'forbidden')
 COERCION_FAILED = ErrorDefinition(0x61, 'coerce')
 RENAMING_FAILED = ErrorDefinition(0x62, 'rename_handler')
 READONLY_FIELD = ErrorDefinition(0x63, 'readonly')
+SETTING_DEFAULT_FAILED = ErrorDefinition(0x64, 'default_setter')
 
 # groups
 ERROR_GROUP = ErrorDefinition(0x80, None)
@@ -352,6 +353,7 @@ class BasicErrorHandler(BaseErrorHandler):
                 0x61: "field '{field}' cannot be coerced: {0}",
                 0x62: "field '{field}' cannot be renamed: {0}",
                 0x63: "field is read-only",
+                0x64: "default value for '{field}' cannot be set: {0}",
 
                 0x81: "mapping doesn't validate subschema: {0}",
                 0x82: "one or more sequence-items don't validate: {0}",

--- a/cerberus/schema.py
+++ b/cerberus/schema.py
@@ -51,7 +51,7 @@ class DefinitionSchema(MutableMapping):
         self.validator = validator
         self.schema = schema
         self.validation_schema = SchemaValidationSchema(validator)
-        self.schema_validator = SchemaValidator(
+        self.schema_validator = SchemaValidator(  # noqa
             UnvalidatedSchema(), error_handler=errors.SchemaErrorHandler,
             target_schema=schema, target_validator=validator)
         self.schema_validator.allow_unknown = self.validation_schema

--- a/docs/customize.rst
+++ b/docs/customize.rst
@@ -125,6 +125,25 @@ a method as ``rename_handler``. The method name must be prefixed with
    >>> MyNormalizer(2).normalized(document, schema)
    {'foo': 4}
 
+Custom Default Setters
+----------------------
+Similar to custom rename handlers, it is also possible to create custom default
+setters.
+
+.. testcode::
+
+    from datetime import datetime
+
+    class MyNormalizer(Validator):
+        def _normalize_default_setter_utcnow(self, document):
+            return datetime.utcnow()
+
+.. doctest::
+
+   >>> schema = {'creation_date': {'type': 'datetime', 'default_setter': 'utcnow'}}
+   >>> MyNormalizer().normalized({}, schema)
+   {'creation_date': datetime.datetime(...)}
+
 Limitations
 -----------
 It may be a bad idea to overwrite particular contributed rules.

--- a/docs/normalization-rules.rst
+++ b/docs/normalization-rules.rst
@@ -62,14 +62,14 @@ You can set default values for missing fields in the document by using the ``def
 .. doctest::
 
    >>> v.schema = {'amount': {'type': 'integer'}, 'kind': {'type': 'string', 'default': 'purchase'}}
-   >>> v.normalized({'amount': 1})
-   {'amount': 1, 'kind': 'purchase'}
+   >>> v.normalized({'amount': 1}) == {'amount': 1, 'kind': 'purchase'}
+   True
 
-   >>> v.normalized({'amount': 1, 'kind': None})
-   {'amount': 1, 'kind': 'purchase'}
+   >>> v.normalized({'amount': 1, 'kind': None}) == {'amount': 1, 'kind': 'purchase'}
+   True
 
-   >>> v.normalized({'amount': 1, 'kind': 'other'})
-   {'amount': 1, 'kind': 'other'}
+   >>> v.normalized({'amount': 1, 'kind': 'other'}) == {'amount': 1, 'kind': 'other'}
+   True
 
 .. versionadded:: 0.10
 

--- a/docs/normalization-rules.rst
+++ b/docs/normalization-rules.rst
@@ -71,6 +71,23 @@ You can set default values for missing fields in the document by using the ``def
    >>> v.normalized({'amount': 1, 'kind': 'other'}) == {'amount': 1, 'kind': 'other'}
    True
 
+You can also define a default setter callable to set the default value
+dynamically. The callable gets called with the current (sub)document as the
+only argument. Callables can even depend on one another, but normalizing will
+fail if there is a unresolvable/circular dependency. If the constraint is a
+string, it points to a :doc:`custom method <customize>`.
+
+.. doctest::
+
+   >>> v.schema = {'a': {'type': 'integer'}, 'b': {'type': 'integer', 'default_setter': lambda doc: doc['a'] + 1}}
+   >>> v.normalized({'a': 1}) == {'a': 1, 'b': 2}
+   True
+
+   >>> v.schema = {'a': {'type': 'integer', 'default_setter': lambda doc: doc['not_there']}}
+   >>> v.normalized({})
+   >>> v.errors
+   {'a': "default value for 'a' cannot be set: Circular/unresolvable dependencies for default setters."}
+
 .. versionadded:: 0.10
 
 .. _type-coercion:

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -441,7 +441,7 @@ expression. It is only tested on string values.
     False
 
     >>> v.errors
-    {'email': "value does not match regex '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$'"}
+    {'email': "value does not match regex '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$'"}
 
 For details on regular expression syntax, see the documentation on the standard
 library's :mod:`re`-module.


### PR DESCRIPTION
Allows the use of computed default values via callables / lambda functions. For an example why this is useful, see https://github.com/nicolaiarocci/eve/pull/815.

This implementation is slightly different (and simpler) than the one in the pull request mentioned above, as here only the current (**sub**)document is passed to the callable. Passing the whole document seemed unnecessarily complex as in that case we would have to take care of the evaluation order of child validators, too. The downside is, of course, that you can only access fields in your current "nesting level".