### PR TITLE
Schema validation

### DIFF
--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -259,7 +259,7 @@ class Validator(object):
 
     def __init_error_handler(self, kwargs):
         error_handler = kwargs.pop('error_handler', errors.BasicErrorHandler)
-        eh_config = kwargs.pop('error_handler_config', dict())
+        eh_config = kwargs.pop('error_handler_config', {})
         if isclass(error_handler) and \
                 issubclass(error_handler, errors.BaseErrorHandler):
             self.error_handler = error_handler(**eh_config)
@@ -472,7 +472,7 @@ class Validator(object):
     def transparent_schema_rules(self, value):
         if isinstance(self._schema, DefinitionSchema):
             self._schema.regenerate_validation_schema()
-            self._schema.update(dict())
+            self._schema.update({})  # trigger validation
         self._config['transparent_schema_rules'] = value
 
     # Document processing
@@ -619,7 +619,7 @@ class Validator(object):
     def __normalize_mapping_per_schema(self, field, mapping, schema):
         validator = self._get_child_validator(
             document_crumb=field, schema_crumb=(field, 'schema'),
-            schema=schema[field].get('schema', dict()),
+            schema=schema[field].get('schema', {}),
             allow_unknown=schema[field].get('allow_unknown', self.allow_unknown),  # noqa
             purge_unknown=schema[field].get('purge_unknown', self.purge_unknown))  # noqa
         mapping[field] = validator.normalized(mapping[field])
@@ -852,7 +852,7 @@ class Validator(object):
                 dep_values = [dep_values]
             context = self.document.copy()
             parts = dep_name.split('.')
-            info = dict()
+            info = {}
 
             for part in parts:
                 if part in context:

--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -27,7 +27,8 @@ toy_error_handler = errors.ToyErrorHandler()
 def dummy_for_rule_validation(rule_constraints):
     def dummy(self, constraint, field, value):
         raise RuntimeError('Dummy method called. Its purpose is to hold just'
-                           'validation constraints for a rule.')
+                           'validation constraints for a rule in its '
+                           'docstring.')
     f = dummy
     f.__doc__ = rule_constraints
     return f

--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -182,16 +182,16 @@ class Validator(object):
         Support for addition and validation of custom data types.
     """
 
-    _inspected_classed = set()
+    _inspected_classes = set()
     is_child = False
     mandatory_validations = ('nullable', )
     priority_validations = ('nullable', 'readonly', 'type')
     _valid_schemas = set()
 
     def __new__(cls, *args, **kwargs):
-        if cls not in cls._inspected_classed:
+        if cls not in cls._inspected_classes:
             cls.__set_introspection_properties()
-            cls._inspected_classed.add(cls)
+            cls._inspected_classes.add(cls)
         return super(Validator, cls).__new__(cls)
 
     @classmethod
@@ -814,7 +814,8 @@ class Validator(object):
             validate_rule(rule)
 
     _validate_allow_unknown = dummy_for_rule_validation(
-        """ {'type': ['boolean', 'dict'], 'validator': 'allow_unknown'} """)
+        """ {'oneof': [{'type': 'boolean'},
+                       {'type': 'dict', 'validator': 'bulk_schema'}]} """)
 
     def _validate_allowed(self, allowed_values, field, value):
         """ {'type': 'list'} """
@@ -1089,7 +1090,8 @@ class Validator(object):
                     self._error(field, errors.REQUIRED_FIELD)
 
     def _validate_schema(self, schema, field, value):
-        """ {'type': ['dict', 'list'], 'validator': 'schema'} """
+        """ {'type': 'dict', 'anyof': [{'validator': 'schema'},
+                                       {'validator': 'bulk_schema'}]} """
         if schema is None:
             return
 

--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -341,8 +341,8 @@ class Validator(object):
                                            value, info)
             self._error([error])
 
-    def __get_child_validator(self, document_crumb=None, schema_crumb=None,
-                              **kwargs):
+    def _get_child_validator(self, document_crumb=None, schema_crumb=None,
+                             **kwargs):
         """ Creates a new instance of Validator-(sub-)class. All initial
         parameters of the parent are passed to the initialization, unless
         a parameter is given as an explicit *keyword*-parameter.
@@ -579,7 +579,7 @@ class Validator(object):
                                                property_rules):
         schema = dict(((k, property_rules) for k in mapping[field]))
         document = dict(((k, k) for k in mapping[field]))
-        validator = self.__get_child_validator(
+        validator = self._get_child_validator(
             document_crumb=(field,), schema_crumb=(field, 'propertyschema'),
             schema=schema)
         result = validator.normalized(document)
@@ -599,7 +599,7 @@ class Validator(object):
 
     def __normalize_mapping_per_valueschema(self, field, mapping, value_rules):
         schema = dict(((k, value_rules) for k in mapping[field]))
-        validator = self.__get_child_validator(
+        validator = self._get_child_validator(
             document_crumb=field, schema_crumb=(field, 'valueschema'),
             schema=schema)
         mapping[field] = validator.normalized(mapping[field])
@@ -608,7 +608,7 @@ class Validator(object):
             self._error(validator._errors)
 
     def __normalize_mapping_per_schema(self, field, mapping, schema):
-        validator = self.__get_child_validator(
+        validator = self._get_child_validator(
             document_crumb=field, schema_crumb=(field, 'schema'),
             schema=schema[field].get('schema', dict()),
             allow_unknown=schema[field].get('allow_unknown', self.allow_unknown),  # noqa
@@ -620,7 +620,7 @@ class Validator(object):
     def __normalize_sequence(self, field, mapping, schema):
         child_schema = dict(((k, schema[field]['schema'])
                              for k in range(len(mapping[field]))))
-        validator = self.__get_child_validator(
+        validator = self._get_child_validator(
             document_crumb=field, schema_crumb=(field, 'schema'),
             schema=child_schema)
         result = validator.normalized(dict((k, v) for k, v
@@ -768,7 +768,7 @@ class Validator(object):
                 # for unknown_fields
                 schema_crumb = 'allow_unknown' if self.is_child \
                     else '__allow_unknown__'
-                validator = self.__get_child_validator(
+                validator = self._get_child_validator(
                     schema_crumb=schema_crumb,
                     schema={field: self.allow_unknown})
                 if not validator({field: value}, normalize=False):
@@ -921,8 +921,8 @@ class Validator(object):
             self._error(field, errors.ITEMS_LENGTH, len(items), len(values))
         else:
             schema = dict((i, definition) for i, definition in enumerate(items))  # noqa
-            validator = self.__get_child_validator(document_crumb=field,
-                                                   schema_crumb=(field, 'items'),  # noqa
+            validator = self._get_child_validator(document_crumb=field,
+                                                  schema_crumb=(field, 'items'),  # noqa
                                                    schema=schema)
             if not validator(dict((i, item) for i, item in enumerate(values)),
                              normalize=False):
@@ -930,7 +930,7 @@ class Validator(object):
 
     # TODO remove on next major release
     def __validate_items_schema(self, items, field, value):
-        validator = self.__get_child_validator(schema=items)
+        validator = self._get_child_validator(schema=items)
         for item in value:
             if not validator(item, normalize=False):
                 self._error(validator._errors)
@@ -950,7 +950,7 @@ class Validator(object):
             del s[operator]
             s.update(definition)
 
-            validator = self.__get_child_validator(
+            validator = self._get_child_validator(
                 schema_crumb=(field, operator, i),
                 schema={field: s})
             if validator({field: value}, normalize=False):
@@ -1025,7 +1025,7 @@ class Validator(object):
         """ {'type': 'dict', 'validator': 'bulk_schema',
             'forbidden': ['rename', 'rename_handler']} """
         if isinstance(value, Mapping):
-            validator = self.__get_child_validator(
+            validator = self._get_child_validator(
                 document_crumb=(field,),
                 schema_crumb=(field, 'propertyschema'),
                 schema=dict(((k, schema) for k in value.keys())))
@@ -1092,16 +1092,16 @@ class Validator(object):
     def __validate_schema_mapping(self, field, schema, value):
         allow_unknown = self.schema[field].get('allow_unknown',
                                                self.allow_unknown)
-        validator = self.__get_child_validator(document_crumb=field,
-                                               schema_crumb=(field, 'schema'),
-                                               schema=schema,
-                                               allow_unknown=allow_unknown)
+        validator = self._get_child_validator(document_crumb=field,
+                                              schema_crumb=(field, 'schema'),
+                                              schema=schema,
+                                              allow_unknown=allow_unknown)
         if not validator(value, update=self.update, normalize=False):
             self._error(validator._errors)
 
     def __validate_schema_sequence(self, field, schema, value):
         schema = dict(((i, schema) for i in range(len(value))))
-        validator = self.__get_child_validator(
+        validator = self._get_child_validator(
             document_crumb=field, schema_crumb=(field, 'schema'),
             schema=schema, allow_unknown=self.allow_unknown)
         validator(dict(((i, v) for i, v in enumerate(value))), normalize=False)
@@ -1133,7 +1133,7 @@ class Validator(object):
             # for x in data_type:
             #     if call_type_validation(x, value):
             #         return
-            validator = self.__get_child_validator(
+            validator = self._get_child_validator(
                 schema={'turing': {'anyof': [{'type': x} for x in data_type]}})
             if validator({'turing': value}):
                 return
@@ -1202,7 +1202,7 @@ class Validator(object):
             'forbidden': ['rename', 'rename_handler']} """
         schema_crumb = (field, 'valueschema')
         if isinstance(value, Mapping):
-            validator = self.__get_child_validator(
+            validator = self._get_child_validator(
                 document_crumb=field, schema_crumb=schema_crumb,
                 schema=dict((k, schema) for k in value))
             validator(value, normalize=False)

--- a/cerberus/errors.py
+++ b/cerberus/errors.py
@@ -168,7 +168,7 @@ class ErrorTreeNode(MutableMapping):
         self.tree_root = self.parent_node.tree_root
         self.path = path[:len(self.parent_node.path) + 1]
         self.errors = ErrorsList()
-        self.descendants = dict()
+        self.descendants = {}
 
     def __add__(self, error):
         self.add(error)
@@ -229,7 +229,7 @@ class ErrorTree(ErrorTreeNode):
         self.tree_root = self
         self.path = ()
         self.errors = []
-        self.descendants = dict()
+        self.descendants = {}
         for error in errors:
             self += error
 
@@ -367,7 +367,7 @@ class BasicErrorHandler(BaseErrorHandler):
                 }
 
     def __init__(self, tree=None):
-        self.tree = dict() if tree is None else tree
+        self.tree = {} if tree is None else tree
 
     def __call__(self, errors=None):
         if errors is not None:
@@ -386,7 +386,7 @@ class BasicErrorHandler(BaseErrorHandler):
                               self.format_message(field, error))
 
     def clear(self):
-        self.tree = dict()
+        self.tree = {}
 
     def format_message(self, field, error):
         return self.messages[error.code]\

--- a/cerberus/platform.py
+++ b/cerberus/platform.py
@@ -3,9 +3,9 @@
 import sys
 
 
-if sys.version_info[0] == 3:
-    _str_type = str
-    _int_types = (int,)
-else:
+if sys.version_info[0] == 2:
     _str_type = basestring  # noqa
     _int_types = (int, long)  # noqa
+else:
+    _str_type = str
+    _int_types = (int,)

--- a/cerberus/schema.py
+++ b/cerberus/schema.py
@@ -32,7 +32,7 @@ class DefinitionSchema(MutableMapping):
                                                 SchemaValidatorMixin)
         return super(DefinitionSchema, cls).__new__(cls)
 
-    def __init__(self, validator, schema=dict()):
+    def __init__(self, validator, schema={}):
         """
         :param validator: An instance of Validator-(sub-)class that uses this
                           schema.
@@ -116,7 +116,7 @@ class DefinitionSchema(MutableMapping):
             self.validator._valid_schemas.add(_hash)
 
     def __cast_keys_to_strings(self, mapping):
-        result = dict()
+        result = {}
         for key in mapping:
             if isinstance(mapping[key], Mapping):
                 value = self.__cast_keys_to_strings(mapping[key])
@@ -141,7 +141,7 @@ class DefinitionSchema(MutableMapping):
 
 
 class UnvalidatedSchema(DefinitionSchema):
-    def __init__(self, schema=dict()):
+    def __init__(self, schema={}):
         if not isinstance(schema, Mapping):
             schema = dict(schema)
         self.schema = schema

--- a/cerberus/schema.py
+++ b/cerberus/schema.py
@@ -5,7 +5,7 @@ from warnings import warn
 
 from . import errors
 from .platform import _str_type
-from .utils import validator_fabric
+from .utils import validator_factory
 
 
 class SchemaError(Exception):
@@ -28,8 +28,8 @@ class DefinitionSchema(MutableMapping):
     def __new__(cls, *args, **kwargs):
         if 'SchemaValidator' not in globals():
             global SchemaValidator
-            SchemaValidator = validator_fabric('SchemaValidator',
-                                               SchemaValidatorMixin)
+            SchemaValidator = validator_factory('SchemaValidator',
+                                                SchemaValidatorMixin)
         return super(DefinitionSchema, cls).__new__(cls)
 
     def __init__(self, validator, schema=dict()):

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -1501,8 +1501,7 @@ class DefinitionSchema(TestBase):
     def test_bad_schema_type_field(self):
         field = 'foo'
         schema = {field: {'schema': {'bar': {'type': 'strong'}}}}
-        self.assertSchemaError(self.document, schema, None,
-                               "{'schema': {'bar': 'unknown rule'}}")
+        self.assertSchemaError(self.document, schema)
 
     def test_invalid_schema(self):
         self.assertSchemaError({}, {'foo': {'unknown': 'rule'}}, None,

--- a/cerberus/utils.py
+++ b/cerberus/utils.py
@@ -17,7 +17,7 @@ def drop_item_from_tuple(t, i):
     return t[:i] + t[i + 1:]
 
 
-def validator_factory(name, mixin=None, class_dict=dict()):
+def validator_factory(name, mixin=None, class_dict={}):
     if 'Validator' not in globals():
         from .cerberus import Validator
 

--- a/cerberus/utils.py
+++ b/cerberus/utils.py
@@ -17,7 +17,7 @@ def drop_item_from_tuple(t, i):
     return t[:i] + t[i + 1:]
 
 
-def validator_fabric(name, mixin=None, class_dict=dict()):
+def validator_factory(name, mixin=None, class_dict=dict()):
     if 'Validator' not in globals():
         from .cerberus import Validator
 

--- a/cerberus/utils.py
+++ b/cerberus/utils.py
@@ -1,4 +1,17 @@
+from collections import Mapping
+
 from .platform import _int_types, _str_type
+
+
+def cast_keys_to_strings(mapping):
+    result = {}
+    for key in mapping:
+        if isinstance(mapping[key], Mapping):
+            value = cast_keys_to_strings(mapping[key])
+        else:
+            value = mapping[key]
+        result[str(type(key)) + str(key)] = value
+    return result
 
 
 def compare_paths_lt(x, y):

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -498,7 +498,7 @@ constraint.
 .. note::
 
     To validate *arbitrary keys* of a mapping, see `propertyschema`_, resp.
-    `valueschema`_ for *arbitrary values* of a mapping.
+    `valueschema`_ for validating *arbitrary values* of a mapping.
 
 schema (list)
 -------------


### PR DESCRIPTION
the main aspect of this pr is the usage of child-validators for schema-validation in order to make that non-blocking.
along with it are changes that are necessary to make that work and smaller fixes.

i also wanted to implement a cache that tracks transformed schemas for optimization and to tackle #176, but since mappings are not hashable that requires some caution, and thus time, and i didn't want to hold back my progress so far.