### PR TITLE
Added Support for `binary` Type

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,3 +36,4 @@ Patches and Suggestions
 - Tobias Betz
 - Trong Hieu HA
 - calve
+- Matthew Ellison

--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -1219,6 +1219,10 @@ class Validator(object):
         if not isinstance(value, _int_types):
             self._error(field, errors.BAD_TYPE)
 
+    def _validate_type_binary(self, field, value):
+        if not isinstance(value, (bytes, bytearray)):
+            self._error(field, errors.BAD_TYPE)
+
     def _validate_type_list(self, field, value):
         if not isinstance(value, Sequence) or isinstance(
                 value, _str_type):

--- a/cerberus/tests/__init__.py
+++ b/cerberus/tests/__init__.py
@@ -18,9 +18,16 @@ class TestBase(unittest.TestCase):
     def setUp(self):
         self.document = {'name': 'john doe'}
         self.schema = {
-            'a_string': {'type': 'string',
-                         'minlength': 2,
-                         'maxlength': 10},
+            'a_string': {
+                'type': 'string',
+                'minlength': 2,
+                'maxlength': 10
+            },
+            'a_binary': {
+                'type': 'binary',
+                'minlength': 2,
+                'maxlength': 10
+            },
             'a_nullable_integer': {
                 'type': 'integer',
                 'nullable': True

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -91,6 +91,10 @@ class TestValidation(TestBase):
     def test_not_a_string(self):
         self.assertBadType('a_string', 'string', 1)
 
+    def test_not_a_binary(self):
+        # 'u' literal prefix produces type `str` in Python 3
+        self.assertBadType('a_binary', 'binary', u"i'm not a binary")
+
     def test_not_a_integer(self):
         self.assertBadType('an_integer', 'integer', "i'm not an integer")
 
@@ -120,10 +124,26 @@ class TestValidation(TestBase):
         self.assertError(field, (field, 'maxlength'), errors.MAX_LENGTH,
                          max_length, (len(value),))
 
+    def test_bad_max_length_binary(self):
+        field = 'a_binary'
+        max_length = self.schema[field]['maxlength']
+        value = b'\x00' * (max_length + 1)
+        self.assertFail({field: value})
+        self.assertError(field, (field, 'maxlength'), errors.MAX_LENGTH,
+                         max_length, (len(value),))
+
     def test_bad_min_length(self):
         field = 'a_string'
         min_length = self.schema[field]['minlength']
         value = "".join(choice(ascii_lowercase) for i in range(min_length - 1))
+        self.assertFail({field: value})
+        self.assertError(field, (field, 'minlength'), errors.MIN_LENGTH,
+                         min_length, (len(value),))
+
+    def test_bad_min_length_binary(self):
+        field = 'a_binary'
+        min_length = self.schema[field]['minlength']
+        value = b'\x00' * (min_length - 1)
         self.assertFail({field: value})
         self.assertError(field, (field, 'minlength'), errors.MIN_LENGTH,
                          min_length, (len(value),))

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -567,6 +567,9 @@ Data type allowed for the key value. Can be one of the following names:
    * - ``string``
      - :func:`py2:basestring`
      - :class:`py3:str`
+   * - ``binary``
+     - :class:`py2:str`
+     - :class:`py3:bytes`, :class:`py3:bytearry`
 
 You can extend this list and support :ref:`custom types <new-types>`.
 
@@ -598,6 +601,9 @@ A list of types can be used to allow different values:
     rules on the field will be skipped and validation will continue on other
     fields. This allows to safely assume that field type is correct when other
     (standard or custom) rules are invoked.
+
+.. versionchanged:: 0.10
+   Added the ``binary`` data type.
 
 .. versionchanged:: 0.9
    If a list of types is given, the key value must match *any* of them.


### PR DESCRIPTION
The binary type is similar to string except for Python 2 it only accepts `str` and for Python 3 it accepts `bytes` or `bytearray`.

---
Example in Python 3:
```python
In [2]: v = Validator({'mybinary': {'type': 'binary'}})

In [3]: v.validate({'mybinary': b'valid'})
Out[3]: True

In [4]: v.validate({'mybinary': bytearray(b'valid')})
Out[4]: True

In [5]: v.validate({'mybinary': 'invalid'})
Out[5]: False
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/nicolaiarocci/cerberus/207)
<!-- Reviewable:end -->
