### PR TITLE
Improve Warning on `propertyschema` Normalization

### DIFF
--- a/cerberus/cerberus.py
+++ b/cerberus/cerberus.py
@@ -587,6 +587,8 @@ class Validator(object):
             self._drop_nodes_from_errorpaths(validator._errors, [], [2, 4])
             self._error(validator._errors)
         for k in result:
+            if k == result[k]:
+                continue
             if result[k] in mapping[field]:
                 warn("Normalizing keys of {path}: {key} already exists, "
                      "its value is replaced."


### PR DESCRIPTION
If the propertyschema ("key") did not change during normalization, do not emit a warning about it being replaced.

Closes #222

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nicolaiarocci/cerberus/224)
<!-- Reviewable:end -->
