### PR TITLE
Fixes #241 and other

### DIFF
--- a/cerberus/__init__.py
+++ b/cerberus/__init__.py
@@ -8,8 +8,9 @@
 
 """
 
-from .cerberus import Validator, DocumentError
-from .schema import rules_set_registry, schema_registry, Registry, SchemaError
+from cerberus.validator import Validator, DocumentError
+from cerberus.schema import (rules_set_registry, schema_registry, Registry,
+                             SchemaError)
 
 
 __version__ = "1.0rc"

--- a/cerberus/__init__.py
+++ b/cerberus/__init__.py
@@ -8,6 +8,8 @@
 
 """
 
+from __future__ import absolute_import
+
 from cerberus.validator import Validator, DocumentError
 from cerberus.schema import (rules_set_registry, schema_registry, Registry,
                              SchemaError)

--- a/cerberus/errors.py
+++ b/cerberus/errors.py
@@ -1,5 +1,7 @@
 """ This module contains the error-related constants and classes. """
 
+from __future__ import absolute_import
+
 from collections import defaultdict, namedtuple, MutableMapping
 from copy import copy
 

--- a/cerberus/errors.py
+++ b/cerberus/errors.py
@@ -2,7 +2,8 @@
 
 from collections import defaultdict, namedtuple, MutableMapping
 from copy import copy
-from .utils import compare_paths_lt, quote_string
+
+from cerberus.utils import compare_paths_lt, quote_string
 
 
 """

--- a/cerberus/schema.py
+++ b/cerberus/schema.py
@@ -226,6 +226,8 @@ class SchemaValidationSchema(UnvalidatedSchema):
 
 
 class SchemaValidatorMixin:
+    """ This validator is extended to validate schemas passed to a Cerberus
+        validator. """
     @property
     def known_rules_set_refs(self):
         return self._config.get('known_rules_set_refs', ())

--- a/cerberus/schema.py
+++ b/cerberus/schema.py
@@ -2,9 +2,10 @@ from collections import Callable, Hashable, Iterable, Mapping, MutableMapping
 from copy import copy
 import json
 
-from . import errors
-from .platform import _str_type
-from .utils import cast_keys_to_strings, get_Validator_class, validator_factory
+from cerberus import errors
+from cerberus.platform import _str_type
+from cerberus.utils import (cast_keys_to_strings, get_Validator_class,
+                            validator_factory)
 
 
 def schema_hash(schema):
@@ -12,10 +13,8 @@ def schema_hash(schema):
         def default(self, o):
             return repr(o)
 
-    _hash = hash(json.dumps(cast_keys_to_strings(schema),
-                            cls=Encoder, sort_keys=True))
-
-    return _hash
+    return hash(json.dumps(cast_keys_to_strings(schema),
+                           cls=Encoder, sort_keys=True))
 
 
 class SchemaError(Exception):
@@ -314,8 +313,8 @@ class SchemaValidatorMixin:
         if isinstance(value, Callable):
             return
         if isinstance(value, _str_type):
-            if value not in self.target_validator.validators and \
-                    value not in self.target_validator.coercers:
+            if value not in self.target_validator.validators + \
+                    self.target_validator.coercers:
                 self._error(field, '%s is no valid coercer' % value)
         elif isinstance(value, Iterable):
             for handler in value:

--- a/cerberus/schema.py
+++ b/cerberus/schema.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from collections import Callable, Hashable, Iterable, Mapping, MutableMapping
 from copy import copy
 import json
@@ -51,7 +53,7 @@ class DefinitionSchema(MutableMapping):
         if not isinstance(schema, Mapping):
             try:
                 schema = dict(schema)
-            except:
+            except Exception:
                 raise SchemaError(
                     errors.SCHEMA_ERROR_DEFINITION_TYPE.format(schema))
 
@@ -71,8 +73,8 @@ class DefinitionSchema(MutableMapping):
             del _new_schema[key]
         except ValueError:
             raise SchemaError("Schema has no field '%s' defined" % key)
-        except:
-            raise
+        except Exception as e:
+            raise e
         else:
             del self.schema[key]
 
@@ -100,7 +102,7 @@ class DefinitionSchema(MutableMapping):
         try:
             schema = self._expand_logical_shortcuts(schema)
             schema = self._expand_subschemas(schema)
-        except:
+        except Exception:
             pass
         return schema
 
@@ -168,8 +170,8 @@ class DefinitionSchema(MutableMapping):
         except ValueError:
             raise SchemaError(errors.SCHEMA_ERROR_DEFINITION_TYPE
                               .format(schema))
-        except:
-            raise
+        except Exception as e:
+            raise e
         else:
             self.schema = _new_schema
 
@@ -250,7 +252,7 @@ class SchemaValidatorMixin:
         """ The validator whose schema is being validated. """
         return self._config['target_validator']
 
-    def _validate_logical(self, rule, none, value):
+    def _validate_logical(self, rule, field, value):
         """ {'allowed': ('allof', 'anyof', 'noneof', 'oneof')} """
         validator = self._get_child_validator(
             document_crumb=rule,

--- a/cerberus/tests/__init__.py
+++ b/cerberus/tests/__init__.py
@@ -192,8 +192,8 @@ class TestBase(unittest.TestCase):
                     self.assertEqual(v_error.info, info)
             except AssertionError:
                 pass
-            except:
-                raise
+            except Exception as e:
+                raise e
             else:
                 in_v_errors = True
                 index = i
@@ -225,8 +225,8 @@ class TestBase(unittest.TestCase):
             self.assertError(*args, **kwargs)
         except AssertionError:
             pass
-        except:
-            raise
+        except Exception as e:
+            raise e
         else:
             raise AssertionError('An unexpected error occurred.')
 

--- a/cerberus/tests/__init__.py
+++ b/cerberus/tests/__init__.py
@@ -1,4 +1,4 @@
-from .. import Validator, SchemaError, DocumentError, errors
+from cerberus import Validator, SchemaError, DocumentError, errors
 
 import sys
 if sys.version_info >= (2, 7):

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 
-import re
 from datetime import date, datetime
 from random import choice
+import re
 from string import ascii_lowercase
 from tempfile import NamedTemporaryFile
-from . import TestBase
-from .. import schema_registry, rules_set_registry, SchemaError, Validator
-from .. import errors
+
+
+from cerberus import (schema_registry, rules_set_registry, SchemaError,
+                      Validator, errors)
+from cerberus.tests import TestBase
 
 
 ValidationError = errors.ValidationError
@@ -1959,3 +1961,15 @@ class TestAssorted(TestBase):
         self.assertGreater(len(self.validator._valid_schemas), 0)
         self.validator.clear_caches()
         self.assertEqual(len(self.validator._valid_schemas), 0)
+
+
+if __name__ == '__main__':
+    import os
+    import sys
+    import unittest
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                 '..', '..')))
+
+    # TODO get pytest.main() working before tackling
+    # https://github.com/nicolaiarocci/cerberus/issues/213
+    unittest.main()

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -6,10 +6,16 @@ import re
 from string import ascii_lowercase
 from tempfile import NamedTemporaryFile
 
+if __name__ == '__main__':
+    import os
+    import sys
+    import unittest  # TODO pytest
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                 '..', '..')))
 
 from cerberus import (schema_registry, rules_set_registry, SchemaError,
-                      Validator, errors)
-from cerberus.tests import TestBase
+                      Validator, errors)  # noqa
+from cerberus.tests import TestBase  # noqa
 
 
 ValidationError = errors.ValidationError
@@ -1978,13 +1984,8 @@ class TestAssorted(TestBase):
         self.assertEqual(len(self.validator._valid_schemas), 0)
 
 
-if __name__ == '__main__':
-    import os
-    import sys
-    import unittest
-    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                                 '..', '..')))
 
+if __name__ == '__main__':
     # TODO get pytest.main() working before tackling
     # https://github.com/nicolaiarocci/cerberus/issues/213
     unittest.main()

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -2003,6 +2003,8 @@ class TestAssorted(TestBase):
         self.validator.clear_caches()
         self.assertEqual(len(self.validator._valid_schemas), 0)
 
+    def test_docstring(self):
+        self.assertTrue(Validator.__doc__)
 
 
 if __name__ == '__main__':

--- a/cerberus/utils.py
+++ b/cerberus/utils.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from collections import Mapping
 
 from cerberus.platform import _int_types, _str_type
@@ -31,6 +33,7 @@ def drop_item_from_tuple(t, i):
 
 
 def get_Validator_class():
+    global Validator
     if 'Validator' not in globals():
         from cerberus.validator import Validator
     return Validator

--- a/cerberus/utils.py
+++ b/cerberus/utils.py
@@ -1,6 +1,6 @@
 from collections import Mapping
 
-from .platform import _int_types, _str_type
+from cerberus.platform import _int_types, _str_type
 
 
 def cast_keys_to_strings(mapping):
@@ -32,7 +32,7 @@ def drop_item_from_tuple(t, i):
 
 def get_Validator_class():
     if 'Validator' not in globals():
-        from .cerberus import Validator
+        from cerberus.validator import Validator
     return Validator
 
 

--- a/cerberus/utils.py
+++ b/cerberus/utils.py
@@ -41,6 +41,8 @@ def get_Validator_class():
 
 def validator_factory(name, mixin=None, class_dict={}):
     """ Dynamically create a :class:`~cerberus.Validator` subclass.
+        Docstrings of mixin-classes will be added to the resulting
+        class' one if ``__doc__`` is not in :obj:`class_dict`.
 
     :param name: The name of the new class.
     :type name: :class:`str`
@@ -58,6 +60,10 @@ def validator_factory(name, mixin=None, class_dict={}):
         bases = (Validator,) + mixin
     else:
         bases = (Validator, mixin)
+
+    docstrings = [x.__doc__ for x in bases if x.__doc__]
+    if len(docstrings) > 1 and '__doc__' not in class_dict:
+        class_dict.update({'__doc__': '\n'.join(docstrings)})
 
     return type(name, bases, class_dict)
 

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -811,14 +811,11 @@ class Validator(object):
 
     def _validate_allowed(self, allowed_values, field, value):
         """ {'type': 'list'} """
-        if isinstance(value, _str_type):
-            if value not in allowed_values:
-                self._error(field, errors.UNALLOWED_VALUE, value)
-        elif isinstance(value, Sequence) and not isinstance(value, _str_type):
+        if isinstance(value, Iterable) and not isinstance(value, _str_type):
             unallowed = set(value) - set(allowed_values)
             if unallowed:
                 self._error(field, errors.UNALLOWED_VALUES, list(unallowed))
-        elif isinstance(value, int):
+        else:
             if value not in allowed_values:
                 self._error(field, errors.UNALLOWED_VALUE, value)
 

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -944,34 +944,39 @@ class Validator(object):
                 self._drop_nodes_from_errorpaths(validator._errors, [], [3])
                 _errors.extend(validator._errors)
 
-        if operator == 'anyof' and valid_counter < 1:
-            self._error(field, errors.ANYOF, _errors,
-                        valid_counter, len(definitions))
-        elif operator == 'allof' and valid_counter < len(definitions):
-            self._error(field, errors.ALLOF, _errors,
-                        valid_counter, len(definitions))
-        elif operator == 'noneof' and valid_counter > 0:
-            self._error(field, errors.NONEOF, _errors,
-                        valid_counter, len(definitions))
-        elif operator == 'oneof' and valid_counter != 1:
-            self._error(field, errors.ONEOF, _errors,
-                        valid_counter, len(definitions))
+        return valid_counter, _errors
 
     def _validate_anyof(self, definitions, field, value):
         """ {'type': 'list', 'logical': 'anyof'} """
-        self.__validate_logical('anyof', definitions, field, value)
+        valids, _errors = \
+            self.__validate_logical('anyof', definitions, field, value)
+        if valids < 1:
+            self._error(field, errors.ANYOF, _errors,
+                        valids, len(definitions))
 
     def _validate_allof(self, definitions, field, value):
         """ {'type': 'list', 'logical': 'allof'} """
-        self.__validate_logical('allof', definitions, field, value)
+        valids, _errors = \
+            self.__validate_logical('allof', definitions, field, value)
+        if valids < len(definitions):
+            self._error(field, errors.ALLOF, _errors,
+                        valids, len(definitions))
 
     def _validate_noneof(self, definitions, field, value):
         """ {'type': 'list', 'logical': 'noneof'} """
-        self.__validate_logical('noneof', definitions, field, value)
+        valids, _errors = \
+            self.__validate_logical('noneof', definitions, field, value)
+        if valids > 0:
+            self._error(field, errors.NONEOF, _errors,
+                        valids, len(definitions))
 
     def _validate_oneof(self, definitions, field, value):
         """ {'type': 'list', 'logical': 'oneof'} """
-        self.__validate_logical('oneof', definitions, field, value)
+        valids, _errors = \
+            self.__validate_logical('oneof', definitions, field, value)
+        if valids != 1:
+            self._error(field, errors.ONEOF, _errors,
+                        valids, len(definitions))
 
     def _validate_max(self, max_value, field, value):
         """ {'nullable': False } """

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -275,6 +275,7 @@ class Validator(object):
             child_config['root_allow_unknown'] = self.allow_unknown
             child_config['root_document'] = self.document
             child_config['root_schema'] = self.schema
+
         child_validator = self.__class__(**child_config)
 
         if document_crumb is None:
@@ -719,13 +720,6 @@ class Validator(object):
         :return: ``True`` if validation succeeds, otherwise ``False``. Check
                  the :func:`errors` property for a list of processing errors.
         :rtype: :class:`bool`
-
-        .. versionchanged:: 1.0
-           Removed 'context'-argument, Validator takes care of setting it now.
-           It's accessible as ``self.root_document``.
-
-        .. versionchanged:: 0.4.0
-           Support for update mode.
         """
         self.update = update
         self._unrequired_by_excludes = set()
@@ -922,9 +916,9 @@ class Validator(object):
             schema = dict((i, definition) for i, definition in enumerate(items))  # noqa
             validator = self._get_child_validator(document_crumb=field,
                                                   schema_crumb=(field, 'items'),  # noqa
-                                                   schema=schema)
+                                                  schema=schema)
             if not validator(dict((i, item) for i, item in enumerate(values)),
-                             normalize=False):
+                             update=self.update, normalize=False):
                 self._error(field, errors.BAD_ITEMS, validator._errors)
 
     def __validate_logical(self, operator, definitions, field, value):
@@ -944,7 +938,7 @@ class Validator(object):
             validator = self._get_child_validator(
                 schema_crumb=(field, operator, i),
                 schema={field: s})
-            if validator({field: value}, normalize=False):
+            if validator({field: value}, update=self.update, normalize=False):
                 valid_counter += 1
             else:
                 self._drop_nodes_from_errorpaths(validator._errors, [], [3])
@@ -1199,7 +1193,7 @@ class Validator(object):
             validator = self._get_child_validator(
                 document_crumb=field, schema_crumb=schema_crumb,
                 schema=dict((k, schema) for k in value))
-            validator(value, normalize=False)
+            validator(value, update=self.update, normalize=False)
             if validator._errors:
                 self._drop_nodes_from_errorpaths(validator._errors, [], [2])
                 self._error(field, errors.VALUESCHEMA, validator._errors)

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -8,6 +8,8 @@
     Full documentation is available at http://python-cerberus.org
 """
 
+from __future__ import absolute_import
+
 from ast import literal_eval
 from collections import Hashable, Iterable, Mapping, Sequence
 from copy import copy
@@ -83,7 +85,7 @@ class Validator(object):
                           initialization of the error handler.
                           Default: :class:`~cerberus.errors.BasicErrorHandler`.
     :type error_handler: class or instance based on
-                         :class:`~erberus.errors.BaseErrorHandler>` or
+                         :class:`~cerberus.errors.BaseErrorHandler` or
                          :class:`tuple`
     """  # noqa
 
@@ -203,7 +205,7 @@ class Validator(object):
 
                      - the invalid field's name
 
-                     - the error-reference, see :mod:`errors`
+                     - the error-reference, see :mod:`cerberus.errors`
 
                      - arbitrary, supplemental information about the error
 
@@ -298,7 +300,7 @@ class Validator(object):
         methodname = '_{0}_{1}'.format(domain, rule.replace(' ', '_'))
         return getattr(self, methodname, None)
 
-    def _drop_nodes_from_errorpaths(self, errors, dp_items, sp_items):
+    def _drop_nodes_from_errorpaths(self, _errors, dp_items, sp_items):
         """ Removes nodes by index from an errorpath, relatively to the
             basepaths of self.
 
@@ -309,7 +311,7 @@ class Validator(object):
         """
         dp_basedepth = len(self.document_path)
         sp_basedepth = len(self.schema_path)
-        for error in errors:
+        for error in _errors:
             for i in sorted(dp_items, reverse=True):
                 error.document_path = \
                     drop_item_from_tuple(error.document_path, dp_basedepth + i)
@@ -922,7 +924,7 @@ class Validator(object):
         """ Validates value against all definitions and logs errors according
             to the operator. """
         valid_counter = 0
-        _errors = []
+        _errors = errors.ErrorList()
 
         for i, definition in enumerate(definitions):
             schema = {field: definition.copy()}
@@ -1261,7 +1263,7 @@ class InspectedValidator(type):
                 docstring = docstring.split(RULE_SCHEMA_SEPERATOR)[1]
             try:
                 result = literal_eval(docstring.strip())
-            except:
+            except Exception:
                 result = {}
 
         if not result:

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -1209,6 +1209,11 @@ RULE_SCHEMA_SEPERATOR = \
 
 class InspectedValidator(type):
     """ Metaclass for all validators """
+    def __new__(cls, *args):
+        if '__doc__' not in args[2]:
+            args[2].update({'__doc__': args[1][0].__doc__})
+        return super(InspectedValidator, cls).__new__(cls, *args)
+
     def __init__(cls, *args):
         def attributes_with_prefix(prefix):
             return tuple(x.split('_', 2)[-1] for x in dir(cls)

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -914,7 +914,7 @@ class Validator(object):
             validator = self._get_child_validator(document_crumb=field,
                                                   schema_crumb=(field, 'items'),  # noqa
                                                   schema=schema)
-            if not validator(dict((i, item) for i, item in enumerate(values)),
+            if not validator(dict((i, value) for i, value in enumerate(values)),
                              update=self.update, normalize=False):
                 self._error(field, errors.BAD_ITEMS, validator._errors)
 

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -15,11 +15,11 @@ from datetime import date, datetime
 import re
 from warnings import warn
 
-from . import errors
-from .platform import _int_types, _str_type
-from .schema import schema_registry, rules_set_registry, DefinitionSchema, \
-    SchemaError
-from .utils import drop_item_from_tuple, isclass
+from cerberus import errors
+from cerberus.platform import _int_types, _str_type
+from cerberus.schema import (schema_registry, rules_set_registry,
+                             DefinitionSchema, SchemaError)
+from cerberus.utils import drop_item_from_tuple, isclass
 
 
 toy_error_handler = errors.ToyErrorHandler()
@@ -848,7 +848,7 @@ class Validator(object):
             if (not isinstance(dep_values, Sequence) or
                     isinstance(dep_values, _str_type)):
                 dep_values = [dep_values]
-            context = self.document.copy()
+            context = self.document
             parts = dep_name.split('.')
             info = {}
 
@@ -1213,9 +1213,8 @@ class InspectedValidator(type):
     """ Metaclass for all validators """
     def __init__(cls, *args):
         def attributes_with_prefix(prefix):
-            rules = ['_'.join(x.split('_')[2:]) for x in dir(cls)
-                     if x.startswith('_' + prefix)]
-            return tuple(rules)
+            return tuple(x.split('_', 2)[-1] for x in dir(cls)
+                         if x.startswith('_' + prefix))
 
         super(InspectedValidator, cls).__init__(*args)
 
@@ -1271,7 +1270,7 @@ class InspectedValidator(type):
 
         if not result:
             warn("No validation schema is defined for the arguments of rule "
-                 "'%s'" % '_'.join(method_name.split('_')[2:]))
+                 "'%s'" % method_name.split('_', 2)[-1])
 
         return result
 

--- a/docs/customize.rst
+++ b/docs/customize.rst
@@ -178,6 +178,11 @@ To make use of additional contextual information in a sub-class of
                 self.additional_context = kwargs['additional_context']
             super(MyValidator, self).__init__(*args, **kwargs)
 
+        # alternatively define a property
+        @property
+        def additional_context(self):
+            return self._config.get('additional_context', 'bar')
+
         def _validate_type_foo(self, field, value):
             make_use_of(self.additional_context)
 
@@ -186,6 +191,11 @@ This ensures that the additional context will be available in
 validation.
 
 .. versionadded:: 0.9
+
+There's a function :func:`~cerberus.utils.validator_factory` to get a
+:class:`Validator` mutant with concatenated docstrings.
+
+.. versionadded:: 1.0
 
 
 Relevant `Validator`-attributes

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -11,8 +11,9 @@ For a full alaboration refer to :ref:`this paragraph <allowing-the-unknown>`.
 
 allowed
 -------
-Allowed values for ``string``, ``list`` and ``int`` types. Validation will fail
-if target values are not included in the allowed list.
+If the target value is an :term:`iterable`, all its members must be in the
+list of allowed values. Other types of target values will validate if the
+value is in that list.
 
 .. doctest::
 

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -49,14 +49,12 @@ value is in that list.
 
 allof
 -----
-
 Validates if *all* of the provided constraints validates the field. See `\*of-rules`_ for details.
 
 .. versionadded:: 0.9
 
 anyof
 -----
-
 Validates if *any* of the provided constraints validates the field. See `\*of-rules`_ for details.
 
 .. versionadded:: 0.9
@@ -120,7 +118,8 @@ but also any of their allowed values must be matched.
    >>> v.errors
    {'field2': ["depends on these values: {'field1': 'one'}"]}
 
-Dependencies on sub-document fields are also supported:
+Declaring dependencies on sub-document fields with dot-notation is also
+supported:
 
 .. doctest::
 
@@ -151,7 +150,8 @@ Dependencies on sub-document fields are also supported:
 empty
 -----
 Only applies to string fields. If ``False`` validation will fail if the value
-is empty. Defaults to ``True``.
+is empty. Setting it to ``True`` manually is pointless as it behaves like
+omitting the rule at all.
 
 .. doctest::
 
@@ -236,8 +236,9 @@ values:
 
 items
 -----
-When a list, ``items`` defines a list of values allowed in a ``list`` type of
-fixed length in the given order:
+Validates the items of any iterable against a sequence of rules that must
+validate each index-correspondent item. The items will only be evaluated if
+the given iterable's size matches the definition's.
 
 .. doctest::
 
@@ -255,8 +256,7 @@ See `schema (list)`_ rule for dealing with arbitrary length ``list`` types.
 
 keyschema
 ---------
-This is the counterpart to ``valueschema`` that validates the `keys` of a
-``dict``.
+Validation schema for all keys of a :term:`mapping`.
 
 .. doctest::
 
@@ -690,8 +690,7 @@ The constraint can also be a sequence of these that will be called consecutively
 
 valueschema
 -----------
-Validation schema for all values of a ``dict``. The ``dict`` can have arbitrary
-keys, the values for all of which must validate with given schema:
+Validation schema for all values of a :term:`mapping`.
 
 .. doctest::
 


### PR DESCRIPTION
here's a fix for #241 included. @gwainer can you check that it also covers your issue?

i hope i didn't miss anything, the solution was not as straight-forward as finding the problem. there's been a blind spot concerning the affects of other rules so far.

why did i end up renaming the `cerberus` module? well,

1. i wanted to run the tests on Pyston and thus needed an invokable script. (the result is surprisingly only one fail that may be a bug in Pyston's exception system.) unfortunately it doesn't work with pytest yet.
2. i noticed at this point that the imports all don't follow PEP8 which favor absolute imports and fixed it.
3. suddenly it looked javaish (`from cerberus.cerberus import x`) and was ambigous (`from cerberus.import x`), hence the renaming

there's no rush to merge as i will have a look at the incorrect error representation from the initial post.