### PR TITLE
fix issue #250

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Patches and Suggestions
 - C.D. Clark III
 - Damián Nohales
 - Danielle Pizzolli
+- Davis Kirkendall
 - Denis Carriere
 - Dominik Kellner
 - Eelke Hermens

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -1581,7 +1581,7 @@ class TestNormalization(TestBase):
             document)
 
     def test_issue_250(self):
-        # https://github.com/nicolaiarocci/cerberus/issues/211
+        # https://github.com/nicolaiarocci/cerberus/issues/250
         schema = {
             'list': {
                 'type': 'list',
@@ -1601,7 +1601,7 @@ class TestNormalization(TestBase):
                          v_errors=_errors)
 
     def test_issue_250_no_type_pass_on_list(self):
-        # https://github.com/nicolaiarocci/cerberus/issues/211
+        # https://github.com/nicolaiarocci/cerberus/issues/250
         schema = {
             'list': {
                 'schema': {
@@ -1615,7 +1615,7 @@ class TestNormalization(TestBase):
         self.assertNormalized(document, document, schema)
 
     def test_issue_250_no_type_fail_on_dict(self):
-        # https://github.com/nicolaiarocci/cerberus/issues/211
+        # https://github.com/nicolaiarocci/cerberus/issues/250
         schema = {
             'list': {
                 'schema': {
@@ -1624,13 +1624,26 @@ class TestNormalization(TestBase):
                 }
             }
         }
-        document = {'list': {'a': 'something'}}
+        document = {'list': {'a': {'a': 'known'}}}
         self.validator(document, schema)
         _errors = self.validator._errors
         self.assertEqual(len(_errors), 1)
         self.assertError('list', ('list', 'schema'),
                          errors.BAD_TYPE_FOR_SCHEMA, schema['list']['schema'],
                          v_errors=_errors)
+
+    def test_issue_250_no_type_fail_pass_on_other(self):
+        # https://github.com/nicolaiarocci/cerberus/issues/250
+        schema = {
+            'list': {
+                'schema': {
+                    'allow_unknown': True,
+                    'schema': {'a': {'type': 'string'}}
+                }
+            }
+        }
+        document = {'list': 1}
+        self.assertNormalized(document, document, schema)
 
 
 class TestDefinitionSchema(TestBase):

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -1580,6 +1580,26 @@ class TestNormalization(TestBase):
                                      always_return_document=True),
             document)
 
+    def test_issue_250(self):
+        # https://github.com/nicolaiarocci/cerberus/issues/211
+        schema = {
+            'list': {
+                'type': 'list',
+                'schema': {
+                    'type': 'dict',
+                    'allow_unknown': True,
+                    'schema': {'a': {'type': 'string'}}
+                }
+            }
+        }
+        document = {'list': {'is_a': 'mapping'}}
+        self.validator(document, schema)
+        _errors = self.validator._errors
+        self.assertEqual(len(_errors), 1)
+        self.assertError('list', ('list', 'type'),
+                         errors.BAD_TYPE, schema['list']['type'],
+                         v_errors=_errors)
+
 
 class TestDefinitionSchema(TestBase):
     def test_empty_schema(self):

--- a/cerberus/tests/tests.py
+++ b/cerberus/tests/tests.py
@@ -1600,6 +1600,38 @@ class TestNormalization(TestBase):
                          errors.BAD_TYPE, schema['list']['type'],
                          v_errors=_errors)
 
+    def test_issue_250_no_type_pass_on_list(self):
+        # https://github.com/nicolaiarocci/cerberus/issues/211
+        schema = {
+            'list': {
+                'schema': {
+                    'allow_unknown': True,
+                    'type': 'dict',
+                    'schema': {'a': {'type': 'string'}}
+                }
+            }
+        }
+        document = {'list': [{'a': 'known', 'b': 'unknown'}]}
+        self.assertNormalized(document, document, schema)
+
+    def test_issue_250_no_type_fail_on_dict(self):
+        # https://github.com/nicolaiarocci/cerberus/issues/211
+        schema = {
+            'list': {
+                'schema': {
+                    'allow_unknown': True,
+                    'schema': {'a': {'type': 'string'}}
+                }
+            }
+        }
+        document = {'list': {'a': 'something'}}
+        self.validator(document, schema)
+        _errors = self.validator._errors
+        self.assertEqual(len(_errors), 1)
+        self.assertError('list', ('list', 'schema'),
+                         errors.BAD_TYPE_FOR_SCHEMA, schema['list']['schema'],
+                         v_errors=_errors)
+
 
 class TestDefinitionSchema(TestBase):
     def test_empty_schema(self):

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -542,7 +542,9 @@ class Validator(object):
         for field in mapping:
             if field not in schema:
                 continue
-            if isinstance(mapping[field], Mapping):
+            # TODO: This check conflates validation and normalization
+            if isinstance(mapping[field], Mapping) and \
+                    not schema[field].get('type') == 'list':
                 if 'keyschema' in schema[field]:
                     self.__normalize_mapping_per_keyschema(
                         field, mapping, schema[field]['keyschema'])

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -606,13 +606,14 @@ A list of types can be used to allow different values:
 
 .. note::
 
-    While the ``type`` is not required to be set at all, it is not encouraged to
-    leave it unset especially when using more complex rules such as ``schema``.
-    If you decide you still don't want to set an explicit type, rules such as
-    ``schema`` are only applied to values where the rules can actually be used
-    (such as `'dict'` and `'list'`). Also, the the case of ``schema``, cerberus
-    will try to decide depending on what the ``schema`` rule looks like if a
-    `'list'` or a `'dict'` is required.
+    While the ``type`` rule is not required to be set at all, it is not
+    encouraged to leave it unset especially when using more complex rules such
+    as ``schema``. If you decide you still don't want to set an explicit type,
+    rules such as ``schema`` are only applied to values where the rules can
+    actually be used (such as ``dict`` and ``list``). Also, in the case of
+    ``schema``, cerberus will try to decide if a ``list`` or a ``dict`` type
+    rule is more appropriate and infer it depending on what the ``schema`` rule
+    looks like.
 
 .. note::
 

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -606,6 +606,16 @@ A list of types can be used to allow different values:
 
 .. note::
 
+    While the ``type`` is not required to be set at all, it is not encouraged to
+    leave it unset especially when using more complex rules such as ``schema``.
+    If you decide you still don't want to set an explicit type, rules such as
+    ``schema`` are only applied to values where the rules can actually be used
+    (such as `'dict'` and `'list'`). Also, the the case of ``schema``, cerberus
+    will try to decide depending on what the ``schema`` rule looks like if a
+    `'list'` or a `'dict'` is required.
+
+.. note::
+
     Please note that type validation is performed before most others which
     exist for the same field (only `nullable`_ and `readonly`_ are considered
     beforehand). In the occurrence of a type failure subsequent validation


### PR DESCRIPTION
This is a start at fixing issue #250 
I looked into this and the problem seems to be that by passing a mapping, the normalizer goes through the "mapping normalizer" code path, which leads to all sorts of problems once the boolean value of "allow_unknown" is encountered.  
The "schema" keyword means something different when set in the context of a sequence (in a mapping, the top level of the schema dictionary defines keys of the schema, in a sequence, it defines the top level is equivalent to the second level of a mapping schema), resulting in the exceptions thrown at the normalization stage.
This has probably been discussed before but if not, it might be sensible to use a different keyword for the lists "schema" like "itemschema" or something like that?