### PR TITLE
Fix NotImplemented does not derive from BaseException

### DIFF
--- a/cerberus/errors.py
+++ b/cerberus/errors.py
@@ -513,9 +513,9 @@ class BasicErrorHandler(BaseErrorHandler):
             nodename = '%s definition %s' % (error.rule, i)
             for child_error in child_errors:
                 if child_error.is_logic_error:
-                    raise NotImplemented
+                    raise NotImplementedError
                 elif child_error.is_group_error:
-                    raise NotImplemented
+                    raise NotImplementedError
                 else:
                     self.insert_error(path + (nodename,),
                                       self.format_message(field, child_error))


### PR DESCRIPTION
Creating an instance of `Validator` with a schema that requires a missing `validator` rule raises a TypeError because `NotImplemented` is not the correct error. It should be `NotImplementedError`.

```
from cerberus import Validator
schema = {'amount': {'validator': 'oddity'}}
v = Validator(schema)
...
TypeError: exceptions must derive from BaseException
```