### PR TITLE
Consistently use new-style classes

### DIFF
--- a/cerberus/errors.py
+++ b/cerberus/errors.py
@@ -86,7 +86,7 @@ SCHEMA_ERROR_MISSING = "validation schema missing"
 """ Error representations """
 
 
-class ValidationError:
+class ValidationError(object):
     """ A simple class to store and query basic error information. """
     def __init__(self, document_path, schema_path, code, rule, constraint,
                  value, info):
@@ -316,7 +316,7 @@ class SchemaErrorTree(ErrorTree):
     tree_type = 'schema'
 
 
-class BaseErrorHandler:
+class BaseErrorHandler(object):
     """ Base class for all error handlers.
         Subclasses are identified as error-handlers with an instance-test. """
     def __init__(self, *args, **kwargs):

--- a/cerberus/schema.py
+++ b/cerberus/schema.py
@@ -225,7 +225,7 @@ class SchemaValidationSchema(UnvalidatedSchema):
                        'type': 'dict'}
 
 
-class SchemaValidatorMixin:
+class SchemaValidatorMixin(object):
     """ This validator is extended to validate schemas passed to a Cerberus
         validator. """
     @property
@@ -359,7 +359,7 @@ class SchemaValidatorMixin:
 ####
 
 
-class Registry:
+class Registry(object):
     """ A registry to store and retrieve schemas and parts of it by a name
     that can be used in validation schemas.
 

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -444,7 +444,7 @@ expression. It is only tested on string values.
     False
 
     >>> v.errors
-    {'email': "value does not match regex '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$'"}
+    {'email': ["value does not match regex '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$'"]}
 
 For details on regular expression syntax, see the documentation on the standard
 library's :mod:`re`-module.


### PR DESCRIPTION
We should use new-style classes wherever possible. There were still four classes not inheriting ```object``` which will lead to confusion when subclassing them (and probably more subtle issues). For example right now you can use ```super``` in a subclass of ```Validator```, but not in a subclass of ```BasicErrorHandler```.