### PR TITLE
`readonly` conflicts with `default` ("simple" fix)

### DIFF
--- a/docs/normalization-rules.rst
+++ b/docs/normalization-rules.rst
@@ -57,6 +57,8 @@ subdocuments like ``allow_unknown`` (see :ref:`allowing-the-unknown`). The defau
 
 .. versionadded:: 1.0
 
+.. _default-values:
+
 Default Values
 --------------
 You can set default values for missing fields in the document by using the ``default`` rule.
@@ -89,6 +91,14 @@ string, it points to a :doc:`custom method <customize>`.
    >>> v.normalized({})
    >>> v.errors
    {'a': ["default value for 'a' cannot be set: Circular dependencies of default setters."]}
+
+You can even use both ``default`` and :ref:`readonly` on the same field. This
+will create a field that cannot be assigned a value manually but it will be
+automatically supplied with a default value by Cerberus. Of course the same
+applies for ``default_setter``.
+
+.. versionchanged:: 1.0.2
+   Can be used in conjunction with :ref:`readonly`.
 
 .. versionadded:: 1.0
 

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -420,12 +420,18 @@ Validates if *exactly one* of the provided constraints applies. See `\*of-rules`
 
 .. versionadded:: 0.9
 
+.. _readonly:
+
 readonly
 --------
 If ``True`` the value is readonly. Validation will fail if this field is
 present in the target dictionary. This is useful, for example, when receiving
 a payload which is to be validated before it is sent to the datastore. The field
 might be provided by the datastore, but should not writable.
+
+.. versionchanged:: 1.0.2
+   Can be used in conjunction with ``default`` and ``default_setter``,
+   see :ref:`Default Values <default-values>`.
 
 regex
 -----


### PR DESCRIPTION
This is a careful fix for issue #268 without introducing any new features (like in #272) and without any (known) breaking changes.

For the full discussion see #272.