### PR TITLE
Added failing test for anyof_type inside rules registry

### DIFF
--- a/cerberus/tests/test_registries.py
+++ b/cerberus/tests/test_registries.py
@@ -45,3 +45,9 @@ def test_references_remain_unresolved(validator):
     assert 'booleans' == validator.schema['foo']
     s = rules_set_registry._storage['booleans']['valueschema']
     assert 'boolean' == s
+
+
+def test_rules_registry_with_anyof_type(validator):
+    rules_set_registry.add('string_or_integer', {'anyof_type': ['string', 'integer']})
+    schema = {'soi': 'string_or_integer'}
+    assert_success({'soi': 'hello'}, schema)


### PR DESCRIPTION
I combined two tests: test_references_remain_unresolved and test_anyof_type.
New test defines rule in registry with anyof_type and uses it to validate schema.
Here is the error:

```
__________________________________________________________________________ test_rules_registry_with_anyof_type __________________________________________________________________________

validator = <cerberus.validator.Validator object at 0x7f016c579a10>

    def test_rules_registry_with_anyof_type(validator):
        rules_set_registry.add('string_or_integer', {'anyof_type': ['string', 'integer']})
        schema = {'soi': 'string_or_integer'}
>       assert_success({'soi': 'hello'}, schema)

cerberus/tests/test_registries.py:53: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
cerberus/tests/__init__.py:68: in assert_success
    result = validator(document, schema, update)
cerberus/validator.py:738: in validate
    self.__init_processing(document, schema)
cerberus/validator.py:455: in __init_processing
    self.schema = DefinitionSchema(self, schema)
cerberus/schema.py:67: in __init__
    self.validate(schema)
cerberus/schema.py:186: in validate
    self._validate(schema)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <[AttributeError("'DefinitionSchema' object has no attribute 'schema'") raised in repr()] SafeRepr object at 0x7f016c66aef0>
schema = {'soi': {'anyof_type': ['string', 'integer']}}

    def _validate(self, schema):
        """ Validates a schema that defines rules against supported rules.
    
            :param schema: The schema to be validated as a legal cerberus schema
                           according to the rules of this Validator object.
            """
        if isinstance(schema, _str_type):
            schema = self.validator.schema_registry.get(schema, schema)
    
        if schema is None:
            raise SchemaError(errors.SCHEMA_ERROR_MISSING)
    
        schema = copy(schema)
        for field in schema:
            if isinstance(schema[field], _str_type):
                schema[field] = rules_set_registry.get(schema[field],
                                                       schema[field])
    
        if not self.schema_validator(schema, normalize=False):
>           raise SchemaError(self.schema_validator.errors)
E           SchemaError: {'soi': [{'anyof_type': ['unknown rule']}]}

cerberus/schema.py:208: SchemaError
========================================================================= 1 failed, 179 passed in 0.64 seconds ==========================================================================

```