### PR TITLE
Handle unicode in 'allowed' 

### DIFF
--- a/cerberus/errors.py
+++ b/cerberus/errors.py
@@ -1,3 +1,4 @@
+# -*-: coding utf-8 -*-
 """ This module contains the error-related constants and classes. """
 
 from __future__ import absolute_import
@@ -459,9 +460,15 @@ class BasicErrorHandler(BaseErrorHandler):
         self.tree = {}
 
     def format_message(self, field, error):
-        return self.messages[error.code]\
-            .format(*error.info, constraint=error.constraint,
-                    field=field, value=error.value)
+        message = self.messages[error.code]
+        try:
+            if isinstance(error.value, unicode):
+                message = unicode(message)
+        except NameError:
+            pass
+
+        return message.format(*error.info, constraint=error.constraint,
+                              field=field, value=error.value)
 
     def insert_error(self, path, node):
         """ Adds an error or sub-tree to :attr:tree.

--- a/cerberus/errors.py
+++ b/cerberus/errors.py
@@ -7,6 +7,7 @@ from collections import defaultdict, namedtuple, MutableMapping
 from copy import copy, deepcopy
 from pprint import pformat
 
+from cerberus.platform import py2_error_unicode_fix
 from cerberus.utils import compare_paths_lt, quote_string
 
 
@@ -447,6 +448,7 @@ class BasicErrorHandler(BaseErrorHandler):
     def __str__(self):
         return pformat(self.pretty_tree)
 
+    @py2_error_unicode_fix
     def add(self, error):
         if error.is_logic_error:
             self.insert_logic_error(error)
@@ -460,15 +462,9 @@ class BasicErrorHandler(BaseErrorHandler):
         self.tree = {}
 
     def format_message(self, field, error):
-        message = self.messages[error.code]
-        try:
-            if isinstance(error.value, unicode):
-                message = unicode(message)
-        except NameError:
-            pass
-
-        return message.format(*error.info, constraint=error.constraint,
-                              field=field, value=error.value)
+        return self.messages[error.code].format(
+            *error.info, constraint=error.constraint,
+            field=field, value=error.value)
 
     def insert_error(self, path, node):
         """ Adds an error or sub-tree to :attr:tree.

--- a/cerberus/platform.py
+++ b/cerberus/platform.py
@@ -1,6 +1,8 @@
 """ Platform-dependent objects """
 
+import copy
 import sys
+from functools import wraps
 
 
 PYTHON_VERSION = float(sys.version_info[0]) + float(sys.version_info[1]) / 10
@@ -12,3 +14,31 @@ if PYTHON_VERSION < 3:
 else:
     _str_type = str
     _int_types = (int,)
+
+
+def py2_error_unicode_fix(f):
+    """Cerberus error messages expect regular binary strings.
+    If unicode is used in schema message can't be printed.
+
+    This decorator ensures that if legacy Python is used unicode
+    strings are encoded before passing to a function.
+    """
+    @wraps(f)
+    def wrapped(obj, error):
+        if PYTHON_VERSION < 3:
+            error = copy.copy(error)
+            error.document_path = _encode(error.document_path)
+            error.schema_path = _encode(error.schema_path)
+            error.constraint = _encode(error.constraint)
+            error.value = _encode(error.value)
+            error.info = _encode(error.info)
+
+        return f(obj, error)
+    return wrapped
+
+
+def _encode(value):
+    """Helper encoding unicode strings into binary utf-8"""
+    if isinstance(value, unicode):
+        return value.encode('utf-8')
+    return value

--- a/cerberus/platform.py
+++ b/cerberus/platform.py
@@ -1,8 +1,6 @@
 """ Platform-dependent objects """
 
-import copy
 import sys
-from functools import wraps
 
 
 PYTHON_VERSION = float(sys.version_info[0]) + float(sys.version_info[1]) / 10
@@ -14,31 +12,3 @@ if PYTHON_VERSION < 3:
 else:
     _str_type = str
     _int_types = (int,)
-
-
-def py2_error_unicode_fix(f):
-    """Cerberus error messages expect regular binary strings.
-    If unicode is used in schema message can't be printed.
-
-    This decorator ensures that if legacy Python is used unicode
-    strings are encoded before passing to a function.
-    """
-    @wraps(f)
-    def wrapped(obj, error):
-        if PYTHON_VERSION < 3:
-            error = copy.copy(error)
-            error.document_path = _encode(error.document_path)
-            error.schema_path = _encode(error.schema_path)
-            error.constraint = _encode(error.constraint)
-            error.value = _encode(error.value)
-            error.info = _encode(error.info)
-
-        return f(obj, error)
-    return wrapped
-
-
-def _encode(value):
-    """Helper encoding unicode strings into binary utf-8"""
-    if isinstance(value, unicode):
-        return value.encode('utf-8')
-    return value

--- a/cerberus/tests/test_validation.py
+++ b/cerberus/tests/test_validation.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import re
+import sys
 from datetime import datetime, date
 from random import choice
 from string import ascii_lowercase
@@ -997,14 +998,34 @@ def test_unicode_allowed():
     schema = {'letters': {'type': 'string', 'allowed': [u'♄εℓł☺']}}
     assert_success(doc, schema)
 
-    # tested value is Unicode
-    # on Python2 this is failure as 'allowed' is encoded with file coding
-    # on Python3 this is success as 'allowed' is a py3 str
     schema = {'letters': {'type': 'string', 'allowed': ['♄εℓł☺']}}
-    assert_fail(doc, schema)
-
     doc = {'letters': '♄εℓł☺'}
     assert_success(doc, schema)
+
+
+@mark.skipif(sys.version_info[0] < 3,
+             reason='requires python 3.x')
+def test_unicode_allowed_py3():
+    """ All strings are unicode in Python 3.x. Input doc and schema
+    have equal strings and validation yield success."""
+
+    # issue 280
+    doc = {'letters': u'♄εℓł☺'}
+    schema = {'letters': {'type': 'string', 'allowed': ['♄εℓł☺']}}
+    assert_success(doc, schema)
+
+
+@mark.skipif(sys.version_info[0] > 2,
+             reason='requires python 2.x')
+def test_unicode_allowed_py2():
+    """ Python 2.x encodes value of allowed using default encoding if
+    the string includes characters outside ASCII range. Produced string
+    does not match input which is an unicode string."""
+
+    # issue 280
+    doc = {'letters': u'♄εℓł☺'}
+    schema = {'letters': {'type': 'string', 'allowed': ['♄εℓł☺']}}
+    assert_fail(doc, schema)
 
 
 def test_oneof():

--- a/cerberus/tests/test_validation.py
+++ b/cerberus/tests/test_validation.py
@@ -975,6 +975,26 @@ def test_allof():
     assert_fail(doc, schema)
 
 
+def test_unicode_allowed():
+    # issue 280
+    doc = {'letters': u'♄εℓł☺'}
+
+    schema = {'letters': {'type': 'string', 'allowed': ['a', 'b', 'c']}}
+    assert_fail(doc, schema)
+
+    schema = {'letters': {'type': 'string', 'allowed': [u'♄εℓł☺']}}
+    assert_success(doc, schema)
+
+    # tested value is Unicode
+    # on Python2 this is failure as 'allowed' is encoded with file coding
+    # on Python3 this is success as 'allowed' is a py3 str
+    schema = {'letters': {'type': 'string', 'allowed': ['♄εℓł☺']}}
+    assert_fail(doc, schema)
+
+    doc = {'letters': '♄εℓł☺'}
+    assert_success(doc, schema)
+
+
 def test_oneof():
     # prop1 can only only be:
     # - greater than 10


### PR DESCRIPTION
Hi,
This is a try to fix issue #280. Differences in how Py3 and Py2 are handling the `str` makes the `format_message` method bit too complicated.
Py3 is fine and can handle anything in terms of string handling which can't be said about Py2.
This difference unfortunately makes following test to fail on Py3.
```
doc = {'letters': u'♄εℓł☺'}
schema = {'letters': {'type': 'string', 'allowed': ['♄εℓł☺']}}

# tested value is Unicode
# on Python2 this is failure as 'allowed' is encoded with file coding
# on Python3 this is success as 'allowed' is a py3 str
assert_fail(doc, schema)
```

How should I handle this? Does it matter? 
This case possibly could be an invalid code or bad practice as str will be encoded by Python with the defined encoding making this part a bit ambiguous. I'd expect one to encode unicode endpoints explicitly or use the unicode object.

Also I decided to catch the exception that indicates code runs on Py3 instead of using six module, as you do not have any dependencies.