### PR TITLE
Adds root-indicator for dependencies dot-notation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,16 @@
 sudo: false
 language: python
 cache: pip
-python: 2.7
-addons:
-  apt:
-    sources:
-      - deadsnakes
-    packages:
-      - python3.5
-env:
-  - TOX_ENV=py26
-  - TOX_ENV=py27
-  - TOX_ENV=py33
-  - TOX_ENV=py34
-  - TOX_ENV=py35
-  - TOX_ENV=pypy
-    #- TOX_ENV=pypy3
-  - TOX_ENV=flake8
-install: travis_retry pip install tox
+python:
+  - 2.6
+  - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
+  #- 3.6
+  - 3.6-dev
+  - pypy
+  #- pypy3
+install: travis_retry pip install tox-travis
 script:
-  - tox -e $TOX_ENV
+  - tox

--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -11,11 +11,11 @@ The inspection on and representation of errors is thoroughly overhauled and
 allows a more detailed and flexible handling. Make sure you have look on
 :doc:`errors`.
 
-Also, :attr:`~cerberus.Validator.errors` (as provided by the default 
-:class:`~cerberus.errors.BasicErrorHandler`) values are lists containing 
+Also, :attr:`~cerberus.Validator.errors` (as provided by the default
+:class:`~cerberus.errors.BasicErrorHandler`) values are lists containing
 error messages, and possibly a ``dict`` as last item containing nested errors.
-Previously, they were strings if single errors per field occured; lists 
-otherwise. 
+Previously, they were strings if single errors per field occured; lists
+otherwise.
 
 
 Deprecations
@@ -99,8 +99,8 @@ three steps. Search, Replace and Regex may come at your service.
   1. Remove the second method's argument (probably named ``field``).
   2. Invert the logic of the conditional clauses where is tested what a value
      is not / has not.
-    3. Replace calls to ``self._error`` below such clauses with
-       ``return True``.
+  3. Replace calls to ``self._error`` below such clauses with
+     ``return True``.
 
 A method doesn't need to return ``False`` or any value when expected criteria
 are not met.

--- a/cerberus/errors.py
+++ b/cerberus/errors.py
@@ -9,8 +9,9 @@ from pprint import pformat
 from cerberus.utils import compare_paths_lt, quote_string
 
 
+ErrorDefinition = namedtuple('cerberus_error', 'code, rule')
 """
-Error definition constants
+Error definition class
 
 Each distinguishable error is defined as a two-value-tuple that holds
 a *unique* error id as integer and the rule as string that can cause it.
@@ -19,7 +20,6 @@ The names do not contain a common prefix as they are supposed to be referenced
 within the module namespace, e.g. errors.CUSTOM
 """
 
-ErrorDefinition = namedtuple('cerberus_error', 'code, rule')
 
 # custom
 CUSTOM = ErrorDefinition(0x00, None)

--- a/cerberus/schema.py
+++ b/cerberus/schema.py
@@ -2,21 +2,10 @@ from __future__ import absolute_import
 
 from collections import Callable, Hashable, Iterable, Mapping, MutableMapping
 from copy import copy
-import json
 
 from cerberus import errors
 from cerberus.platform import _str_type
-from cerberus.utils import (cast_keys_to_strings, get_Validator_class,
-                            validator_factory)
-
-
-def schema_hash(schema):
-    class Encoder(json.JSONEncoder):
-        def default(self, o):
-            return repr(o)
-
-    return hash(json.dumps(cast_keys_to_strings(schema),
-                           cls=Encoder, sort_keys=True))
+from cerberus.utils import get_Validator_class, validator_factory, mapping_hash
 
 
 class SchemaError(Exception):
@@ -184,7 +173,7 @@ class DefinitionSchema(MutableMapping):
     def validate(self, schema=None):
         if schema is None:
             schema = self.schema
-        _hash = schema_hash(schema)
+        _hash = mapping_hash(schema)
         if _hash not in self.validator._valid_schemas:
             self._validate(schema)
             self.validator._valid_schemas.add(_hash)
@@ -266,7 +255,7 @@ class SchemaValidatorMixin(object):
         )
 
         for constraints in value:
-            _hash = schema_hash({'turing': constraints})
+            _hash = mapping_hash({'turing': constraints})
             if _hash in self.target_validator._valid_schemas:
                 continue
 
@@ -302,7 +291,7 @@ class SchemaValidatorMixin(object):
             else:
                 value = definition
 
-        _hash = schema_hash({'turing': value})
+        _hash = mapping_hash({'turing': value})
         if _hash in self.target_validator._valid_schemas:
             return
 
@@ -345,7 +334,7 @@ class SchemaValidatorMixin(object):
             else:
                 value = definition
 
-        _hash = schema_hash(value)
+        _hash = mapping_hash(value)
         if _hash in self.target_validator._valid_schemas:
             return
 

--- a/cerberus/tests/test_validation.py
+++ b/cerberus/tests/test_validation.py
@@ -832,6 +832,18 @@ def test_dependencies_dict_with_subodcuments_fields():
                 schema)
 
 
+def test_root_relative_dependencies():
+    # https://github.com/nicolaiarocci/cerberus/issues/288
+    schema = {'package': {'allow_unknown': True,
+                          'schema': {'version': {'dependencies': '^repo'}}},
+              'repo': {}}
+    assert_fail({'package': {'repo': 'somewhere', 'version': 0}}, schema,
+                error=(('package', 'version'),
+                       ('package', 'schema', 'version', 'dependencies'),
+                       errors.DEPENDENCIES_FIELD, '^repo', ('^repo',)))
+    assert_success({'repo': 'somewhere', 'package': {'version': 1}}, schema)
+
+
 def test_dependencies_errors():
     v = Validator({'field1': {'required': False},
                    'field2': {'required': True,

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -654,7 +654,7 @@ class Validator(object):
 
     def __normalize_sequence(self, field, mapping, schema):
         schema = dict(((k, schema[field]['schema'])
-                      for k in range(len(mapping[field]))))
+                       for k in range(len(mapping[field]))))
         document = dict((k, v) for k, v in enumerate(mapping[field]))
         validator = self._get_child_validator(
             document_crumb=field, schema_crumb=(field, 'schema'),
@@ -933,7 +933,7 @@ class Validator(object):
             self._unrequired_by_excludes.add(field)
         for exclude in excludes:
             if (exclude in self.schema and
-               'required' in self.schema[exclude] and
+                'required' in self.schema[exclude] and
                     self.schema[exclude]['required']):
 
                 self._unrequired_by_excludes.add(exclude)
@@ -1046,12 +1046,12 @@ class Validator(object):
     def _validate_maxlength(self, max_length, field, value):
         """ {'type': 'integer'} """
         if isinstance(value, Iterable) and len(value) > max_length:
-                self._error(field, errors.MAX_LENGTH, len(value))
+            self._error(field, errors.MAX_LENGTH, len(value))
 
     def _validate_minlength(self, min_length, field, value):
         """ {'type': 'integer'} """
         if isinstance(value, Iterable) and len(value) < min_length:
-                self._error(field, errors.MIN_LENGTH, len(value))
+            self._error(field, errors.MIN_LENGTH, len(value))
 
     def _validate_nullable(self, nullable, field, value):
         """ {'type': 'boolean'} """

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -808,8 +808,9 @@ class Validator(object):
     __call__ = validate
 
     def validated(self, *args, **kwargs):
-        """ Wrapper around :func:`validate` that returns the normalized and
-            validated document or :obj:`None` if validation failed. """
+        """ Wrapper around :meth:`~cerberus.Validator.validate` that returns
+            the normalized and validated document or :obj:`None` if validation
+            failed. """
         always_return_document = kwargs.pop('always_return_document', False)
         self.validate(*args, **kwargs)
         if self._errors and not always_return_document:

--- a/cerberus/validator.py
+++ b/cerberus/validator.py
@@ -1104,9 +1104,7 @@ class Validator(object):
     _validate_required = dummy_for_rule_validation(""" {'type': 'boolean'} """)
 
     def __validate_required_fields(self, document):
-        """ Validates that required fields are not missing. If dependencies
-            are precised then validate 'required' only if all dependencies
-            are validated.
+        """ Validates that required fields are not missing.
 
         :param document: The document being validated.
         """

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,7 +7,7 @@ Validator Class
 .. autoclass:: cerberus.Validator
   :members: allow_unknown, clear_caches, document, document_error_tree,
             document_path, _error, error_handler, _errors, errors,
-            _get_child_validator, ignore_none_values, is_child,
+            _get_child_validator, ignore_none_values, is_child, _lookup_field,
             mandatory_validations, normalized, priority_validations,
             purge_unknown, recent_error, root_allow_unknown, root_document,
             root_schema, rules_set_registry, schema, schema_error_tree,

--- a/docs/contact.rst
+++ b/docs/contact.rst
@@ -10,7 +10,7 @@ there are several options:
 
 Blog
 ----
-New releases are usually announced on `my Website <http://nicolaiarocci.com/tag/cerberus>`_.
+New releases are usually announced on `my Website <http://nicolaiarocci.com/tags/cerberus>`_.
 
 Twitter
 -------

--- a/docs/customize.rst
+++ b/docs/customize.rst
@@ -231,8 +231,8 @@ into a new instance of :class:`~cerberus.errors.ValidationError`.
 Full disclosure
 ...............
 In order to be able to gain complete insight into the context of an error at a
-later point, you need to call :meth:`~cerberus._error` with two mandatory
-arguments:
+later point, you need to call :meth:`~cerberus.Validator._error` with two
+mandatory arguments:
 
   - the field where the error occurred
   - an instance of a :class:`~cerberus.errors.ErrorDefinition`

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -213,7 +213,7 @@ normalized copy of a document without validating it:
     >>> document = {'model': 'consumerism', 'amount': '1'}
     >>> normalized_document = v.normalized(document, schema)
     >>> type(normalized_document['amount'])
-    <type 'int'>
+    <class 'int'>
 
 .. versionadded:: 1.0
 

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -520,9 +520,8 @@ expression, look for ``(?aiLmsux)`` in that document.
 
 required
 --------
-If ``True`` the key/value pair is mandatory. Validation will fail when it is
-missing, unless :meth:`~cerberus.Validator.validate` is called with
-``update=True``:
+If ``True`` the field is mandatory. Validation will fail when it is missing,
+unless :meth:`~cerberus.Validator.validate` is called with ``update=True``:
 
 .. doctest::
 
@@ -540,9 +539,7 @@ missing, unless :meth:`~cerberus.Validator.validate` is called with
 
    String fields with empty values will still be validated, even when
    ``required`` is set to ``True``. If you don't want to accept empty values,
-   see the empty_ rule. Also, if dependencies_ are declared for the field, its
-   ``required`` rule will only be validated if all dependencies are
-   included with the document.
+   see the empty_ rule.
 
 .. note::
    The evaluation of this rule does not consider any constraints defined with

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -489,7 +489,7 @@ might be provided by the datastore, but should not writable.
 
 .. versionchanged:: 1.0.2
    Can be used in conjunction with ``default`` and ``default_setter``,
-   see :ref:`Default Values <default-values>`.
+   see :ref:`default-values`.
 
 regex
 -----

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -59,15 +59,17 @@ Validates if *any* of the provided constraints validates the field. See `\*of-ru
 
 .. versionadded:: 0.9
 
+.. _dependencies:
+
 dependencies
 ------------
-This rule allows for either a single field, a list or dict of dependencies.
-When a list is provided, all listed fields must be present in order for the
-target field to be validated.
+This rule allows to define either a single field name, a sequence of field
+names or a :term:`mapping` of field names and a sequence of allowed values as
+required in the document if the field defined upon is present in the document.
 
 .. doctest::
 
-   >>> schema = {'field1': {'required': False}, 'field2': {'required': False, 'dependencies': ['field1']}}
+   >>> schema = {'field1': {'required': False}, 'field2': {'required': False, 'dependencies': 'field1'}}
    >>> document = {'field1': 7}
    >>> v.validate(document, schema)
    True
@@ -79,7 +81,26 @@ target field to be validated.
    >>> v.errors
    {'field2': ["field 'field1' is required"]}
 
-When a dictionary is provided, then not only all dependencies must be present,
+
+When multiple field names are defined as dependencies, all of these must be
+present in order for the target field to be validated.
+
+.. doctest::
+
+   >>> schema = {'field1': {'required': False}, 'field2': {'required': False},
+   ...           'field3': {'required': False, 'dependencies': ['field1', 'field2']}}
+   >>> document = {'field1': 7, 'field2': 11, 'field3': 13}
+   >>> v.validate(document, schema)
+   True
+
+   >>> document = {'field2': 11, 'field3': 13}
+   >>> v.validate(document, schema)
+   False
+
+   >>> v.errors
+   {'field3': ["field 'field1' is required"]}
+
+When a mapping is provided, not only all dependencies must be present,
 but also any of their allowed values must be matched.
 
 .. doctest::
@@ -118,7 +139,7 @@ but also any of their allowed values must be matched.
    >>> v.errors
    {'field2': ["depends on these values: {'field1': 'one'}"]}
 
-Declaring dependencies on sub-document fields with dot-notation is also
+Declaring dependencies on subdocument fields with dot-notation is also
 supported:
 
 .. doctest::
@@ -140,6 +161,43 @@ supported:
 
    >>> v.errors
    {'test_field': ["field 'a_dict.bar' is required"]}
+
+When a subdocument is processed the lookup for a field in question starts at
+the level of that document. In order to address the processed document as
+root level, the declaration has to start with a ``^``. An occurance of two
+initial carets (``^^``) is interpreted as a literal, single ``^`` with no
+special meaning.
+
+.. doctest::
+
+   >>> schema = {
+   ...   'test_field': {},
+   ...   'a_dict': {
+   ...     'type': 'dict',
+   ...     'schema': {
+   ...       'foo': {'type': 'string'},
+   ...       'bar': {'type': 'string', 'dependencies': '^test_field'}
+   ...     }
+   ...   }
+   ... }
+
+   >>> document = {'a_dict': {'bar': 'bar'}}
+   >>> v.validate(document, schema)
+   False
+
+   >>> v.errors
+   {'a_dict': [{'bar': ["field '^test_field' is required"]}]}
+
+.. note::
+   If you want to extend semantics of the dot-notation, you can
+   :doc:`override <customize>` the :meth:`~cerberus.Validator._lookup_field`
+   method.
+
+.. note::
+   The evaluation of this rule does not consider any constraints defined with
+   the :ref:`required` rule.
+
+.. versionchanged:: 1.0.2 Support for absolute addressing with ``^``.
 
 .. versionchanged:: 0.8.1 Support for sub-document fields as dependencies.
 
@@ -485,6 +543,10 @@ missing, unless :meth:`~cerberus.Validator.validate` is called with
    see the empty_ rule. Also, if dependencies_ are declared for the field, its
    ``required`` rule will only be validated if all dependencies are
    included with the document.
+
+.. note::
+   The evaluation of this rule does not consider any constraints defined with
+   the :ref:`dependencies` rule.
 
 .. versionchanged:: 0.8
    Check field dependencies.

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist=py26,py27,py33,py34,py35,pypy,pypy3,flake8,doclinks,doctest
+envlist=py26,py27,py33,py34,py35,py36,pypy,pypy3,flake8,doclinks,doctest
 
 [testenv]
 deps=pytest
-commands=py.test cerberus/tests
+commands=pytest cerberus/tests
 
 [testenv:flake8]
 deps=flake8
@@ -27,3 +27,14 @@ commands=make doctest
 [flake8]
 max-line-length=80
 ignore=E731
+
+[tox:travis]
+2.6 = py26
+2.7 = py27
+3.3 = py33
+3.4 = py34
+3.5 = py35,flake8,doclinks,doctest
+#3.6 = py36
+3.6-dev = py36
+pypy = pypy
+pypy3 = pypy3


### PR DESCRIPTION
and deals with minor issues.

fa88972 is arguable though. my superficial observation of pytest runtimes indicates a slower performance of 0 to 0.05 seconds on the whole test suite. i do favor using a builtin over a module anyway.
the ambiguity concerning sequences mentiond ín the docstring also applies to json.