### PR TITLE
.dockerignore actually supports **-globbing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,22 +1,10 @@
 .*
-*.egg-info
-*.orig
-*.pyc
-__pycache__
+**/*.egg-info
+**/*.orig
+**/*.pyc
+**/__pycache__
 build
 dist
 run-docker-tests
 
 docs/_build
-
-# Go language doesn't support **-globbing
-
-*/*.egg-info
-*/*.orig
-*/*.pyc
-*/__pycache__
-
-*/*.egg-info
-*/*/*.orig
-*/*/*.pyc
-*/*/__pycache__


### PR DESCRIPTION
see https://docs.docker.com/engine/reference/builder/#/dockerignore-file

Quote:
> Beyond Go’s filepath.Match rules, Docker also supports a special wildcard string ** that matches any number of directories (including zero). For example, **/*.go will exclude all files that end with .go that are found in all directories, including the root of the build context.